### PR TITLE
Feat/ddd p13 canary plan

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,29 +6,30 @@ This document is the **authoritative replacement** for the legacy Architecture G
 
 ## 📋 Contents
 
-- [Overview](#overview)
-- [Directory Layout](#directory-layout)
-- [Layering Rules & Guardrails](#layering-rules--guardrails)
-- [Dependency Injection & Feature Flags](#dependency-injection--feature-flags)
-- [Error Taxonomy](#error-taxonomy)
-- [Telemetry, Logging & Tracing](#telemetry-logging--tracing)
-- [Feature Modules](#feature-modules)
-  - [Messaging](#messaging)
-  - [Sync](#sync)
-  - [Search](#search)
-  - [Rendering](#rendering)
-  - [Send & Outbox](#send--outbox)
-  - [Enterprise API](#enterprise-api)
-  - [Security](#security)
-  - [Notifications](#notifications)
-  - [Settings](#settings)
-- [Key Data Flows](#key-data-flows)
-- [Caching & Storage](#caching--storage)
-- [Performance Budgets](#performance-budgets)
-- [Platform Considerations](#platform-considerations)
-- [Testing Strategy](#testing-strategy)
-- [Rollout & Kill Switch](#rollout--kill-switch)
-- [Legacy → DDD Mapping](#legacy--ddd-mapping)
+* [Overview](#overview)
+* [Directory Layout](#directory-layout)
+* [Layering Rules & Guardrails](#layering-rules--guardrails)
+* [Dependency Injection & Feature Flags](#dependency-injection--feature-flags)
+* [Error Taxonomy](#error-taxonomy)
+* [Telemetry, Logging & Tracing](#telemetry-logging--tracing)
+* [Feature Modules](#feature-modules)
+
+  * [Messaging](#messaging)
+  * [Sync](#sync)
+  * [Search](#search)
+  * [Rendering](#rendering)
+  * [Send & Outbox](#send--outbox)
+  * [Enterprise API](#enterprise-api)
+  * [Security](#security)
+  * [Notifications](#notifications)
+  * [Settings](#settings)
+* [Key Data Flows](#key-data-flows)
+* [Caching & Storage](#caching--storage)
+* [Performance Budgets](#performance-budgets)
+* [Platform Considerations](#platform-considerations)
+* [Testing Strategy](#testing-strategy)
+* [Rollout & Kill Switch](#rollout--kill-switch)
+* [Legacy → DDD Mapping](#legacy--ddd-mapping)
 
 ---
 
@@ -36,9 +37,9 @@ This document is the **authoritative replacement** for the legacy Architecture G
 
 We use **Domain‑Driven Design** with **Clean Architecture** in a **feature‑first** layout:
 
-- **Features**: `messaging`, `sync`, `search`, `rendering`, `enterprise_api`, `security`, `notifications`, `settings`.
-- **Layers by feature**: `domain`, `application`, `infrastructure`, `presentation` (UI lives outside features in existing GetX controllers; P12 adds *flag‑gated* routing).
-- **Principles**: separation of concerns, dependency inversion, testability, and incremental migration (legacy path remains default until rollout).
+* **Features**: `messaging`, `sync`, `search`, `rendering`, `enterprise_api`, `security`, `notifications`, `settings`.
+* **Layers by feature**: `domain`, `application`, `infrastructure`, `presentation` (UI lives outside features in existing GetX controllers; P12 adds *flag‑gated* routing).
+* **Principles**: separation of concerns, dependency inversion, testability, and incremental migration (legacy path remains default until rollout).
 
 ## Directory Layout
 
@@ -49,7 +50,7 @@ lib/
       domain/            # entities, value objects, repositories, services (interfaces)
       application/       # use cases (orchestration only)
       infrastructure/    # gateways, DAOs, mappers, repositories impl, DI modules
-      presentation/      # Active: ViewModels (GetX) own UI state/commands; legacy UI widgets in app/views/widgets bind to VMs
+      presentation/    # active ViewModels (feature-scoped); UI widgets bind to VMs
   shared/
     di/                  # get_it + injectable bootstrap
     logging/             # Telemetry helper (PII‑safe)
@@ -60,102 +61,100 @@ lib/
 
 ## Layering Rules & Guardrails
 
-- **Domain**: *no* Flutter SDK, *no* platform/DB/SDK imports.
-- **Application**: orchestrates repositories/services; *no* IO or SDKs.
-- **Infrastructure**: the only layer that talks to SDKs (IMAP/SMTP, REST, storage).
-- **Presentation**: UI/controllers; call use cases/facades **via DI**.
-- **Import Enforcer**: run via `dart run tool/import_enforcer.dart` on every CI/commit.
+* **Domain**: *no* Flutter SDK, *no* platform/DB/SDK imports.
+* **Application**: orchestrates repositories/services; *no* IO or SDKs.
+* **Infrastructure**: the only layer that talks to SDKs (IMAP/SMTP, REST, storage).
+* **Presentation**: UI/controllers; call use cases/facades **via DI**.
+* **Import Enforcer**: run via `dart run tool/import_enforcer.dart` on every CI/commit.
 
 ## Dependency Injection & Feature Flags
 
-- **DI**: `get_it` + `injectable`. Bootstrap in `shared/di/injection.dart`.
-- **Feature flags** (GetStorage‑backed):
-  - `ddd.messaging.enabled`, `ddd.send.enabled`, `ddd.search.enabled`, `ddd.notifications.enabled`, `ddd.enterprise_api.enabled`, `ddd.sync.shadow_mode`.
-  - **Kill switch**: `ddd.kill_switch.enabled` — overrides all and forces legacy routing.
-- **P12.3**: Presentation ViewModels own UI orchestration; legacy controllers are deprecated thin adapters (entry‑telemetry + delegation) and will be removed in P12.4. The legacy routing shim has been retired.
+* **DI**: `get_it` + `injectable`. Bootstrap in `shared/di/injection.dart`.
+* **Feature flags** (GetStorage‑backed):
+
+  * `ddd.messaging.enabled`, `ddd.send.enabled`, `ddd.search.enabled`, `ddd.notifications.enabled`, `ddd.enterprise_api.enabled`, `ddd.sync.shadow_mode`.
+  * **Kill switch**: `ddd.kill_switch.enabled` — **overrides all** and forces **legacy** routing.
+* **Presentation orchestration**: ViewModels (MailboxViewModel, ComposeViewModel, SearchViewModel) own UI orchestration; legacy controllers are @Deprecated thin adapters that delegate to VMs. The old `shared/ddd_ui_wiring.dart` shim was removed in **P12.3**.
 
 ## Error Taxonomy
 
 All gateways map errors to sealed classes in `shared/error/errors.dart`:
 
-- `AuthError`, `RateLimitError`, `TransientNetworkError`, `PermanentProtocolError`,
-- `StorageCorruptionError`, `RenderingError`,
-- Crypto: `CryptoError`, `DecryptionError`, `SignatureInvalidError`, `KeyNotFoundError`.
+* `AuthError`, `RateLimitError`, `TransientNetworkError`, `PermanentProtocolError`,
+* `StorageCorruptionError`, `RenderingError`,
+* Crypto: `CryptoError`, `DecryptionError`, `SignatureInvalidError`, `KeyNotFoundError`.
 
 ## Telemetry, Logging & Tracing
 
-- **Telemetry**: `Telemetry.event/time/timeAsync` with PII‑safe IDs (hashed). Fields: `op, folder_id, request_id, path, lat_ms, error_class, cache`.
-- **Spans** (env‑gated export): `FetchHeaders`, `PersistHeaders`, `FetchBody`, `RenderHtml`, `SendSmtp`, `IdleLoop`.
-- **Budgets** tracked: inbox open p50 ≤ 600ms; cached message open p50 ≤ 200ms; sync cycle p50 ≤ 1500ms; DB cap ≤ 800MB; battery drain ≤ 2%/day.
+* **Telemetry**: `Telemetry.event/time/timeAsync` with PII‑safe IDs (hashed). Fields: `op, folder_id, request_id, path, lat_ms, error_class, cache`.
+* **Spans** (env‑gated export): `FetchHeaders`, `PersistHeaders`, `FetchBody`, `RenderHtml`, `SendSmtp`, `IdleLoop`.
+* **Budgets** tracked: inbox open p50 ≤ 600ms; cached message open p50 ≤ 200ms; sync cycle p50 ≤ 1500ms; DB cap ≤ 800MB; battery drain ≤ 2%/day.
 
 ## Feature Modules
 
 ### Messaging
 
-- **Domain**: `Message`, `Folder`, `Thread`, flags & addresses VOs; repo interfaces.
-- **Infra**: IMAP gateway (headers/body/attachments), local store (metadata, bodies, attachments), mapping, repository impl.
-- **Search**: local‑first; remote stub optional; dedupe + sort by date desc; limit.
+* **Domain**: `Message`, `Folder`, `Thread`, flags & addresses VOs; repo interfaces.
+* **Infra**: IMAP gateway (headers/body/attachments), local store (metadata, bodies, attachments), mapping, repository impl.
+* **Search**: local‑first; remote stub optional; dedupe + sort by date desc; limit.
 
 ### Sync
 
-- **Idle** stream via gateway emits `ImapEvent(exists|expunge|flagsChanged)`.
-- **Shadow mode** service coalesces events (300ms); header‑first refresh; retries with jitter; telemetry on `IdleLoop`.
+* **Idle** stream via gateway emits `ImapEvent(exists|expunge|flagsChanged)`.
+* **Shadow mode** service coalesces events (300ms); header‑first refresh; retries with jitter; telemetry on `IdleLoop`.
 
 ### Search
 
-- `SearchQuery` VO; `SearchResult` entity.
-- Repo performs metadata LIKE + optional body (if cached); remote stub disabled by default.
+* `SearchQuery` VO; `SearchResult` entity.
+* Repo performs metadata LIKE + optional body (if cached); remote stub disabled by default.
 
 ### Rendering
 
-- `MessageRenderingService` → `RenderedContent { sanitizedHtml, plainText?, hasRemoteAssets, inlineImages }`.
-- `HtmlSanitizer` strips `<script>`, `<iframe>`, inline `on*`, external CSS, `javascript:`; blocks **remote images** by default; `allowRemote=true` overrides. Also strips `data:` image sources, `srcset`, and dangerous `style=url(...)`.
-- `CidResolver` maps `cid:` to cached attachments; no network.
-- `PreviewCache` (LRU=100) with hit/miss/evict telemetry.
+* `MessageRenderingService` → `RenderedContent { sanitizedHtml, plainText?, hasRemoteAssets, inlineImages }`.
+* `HtmlSanitizer` strips `<script>`, `<iframe>`, inline `on*`, external CSS, `javascript:`; blocks **remote images** by default; `allowRemote=true` overrides. Also strips `data:` image sources, `srcset`, and dangerous `style=url(...)`.
+* `CidResolver` maps `cid:` to cached attachments; no network.
+* `PreviewCache` (LRU=100) with hit/miss/evict telemetry.
 
 ### Send & Outbox
 
-- `SendEmail` use case: Draft → Outbox → SMTP send; idempotent, backoff `1m, 5m, 30m, 2h` capped at 24h; telemetry `SendSmtp`.
+* `SendEmail` use case: Draft → Outbox → SMTP send; idempotent, backoff `1m, 5m, 30m, 2h` capped at 24h; telemetry `SendSmtp`.
 
 ### Enterprise API
 
-- REST gateway over `MailsysApiClient`; 401/403 → `AuthError`, 429 → `RateLimitError` (retry/backoff 1s→60s), 5xx → `TransientNetworkError`.
-- Token store, mappers, and repos for account profile, contacts, signatures.
+* REST gateway over `MailsysApiClient`; 401/403 → `AuthError`, 429 → `RateLimitError` (retry/backoff 1s→60s), 5xx → `TransientNetworkError`.
+* Token store, mappers, and repos for account profile, contacts, signatures.
 
 ### Security
 
-- `CryptoEngine` interface; `EncryptionService` orchestrates crypto + keyring.
-- In‑memory keyring & trust repo; stub crypto engine (no real PGP/S/MIME in P8).
+* `CryptoEngine` interface; `EncryptionService` orchestrates crypto + keyring.
+* In‑memory keyring & trust repo; stub crypto engine (no real PGP/S/MIME in P8).
 
 ### Notifications
 
-- Domain events (`NewMessageArrived`, `MessageFlagChanged`, `SyncFailed`); `NotificationPort` interface.
-- No‑op adapter + coordinator (disabled by default); settings‑aware payload mapping.
+* Domain events (`NewMessageArrived`, `MessageFlagChanged`, `SyncFailed`); `NotificationPort` interface.
+* No‑op adapter + coordinator (disabled by default); settings‑aware payload mapping.
 
 ### Settings
 
-- Typed getters/setters (quiet hours, sound/vibrate, grouping, max notifications, allow remote images) backed by GetStorage with defaults & migration.
+* Typed getters/setters (quiet hours, sound/vibrate, grouping, max notifications, allow remote images) backed by GetStorage with defaults & migration.
 
 ## Key Data Flows
 
 ```mermaid
 sequenceDiagram
-  participant UI as Controller (GetX)
-  participant W as DddUiWiring
+  participant UI as Controller (thin)
+  participant VM as ViewModel
   participant UC as Use Case
   participant REPO as Repository
   participant GW as Gateway/Store
 
-  UI->>W: fetchInbox(folderId)
-  alt Flags OFF or Kill-Switch ON
-    W-->>UI: return false (legacy path)
-  else DDD Routed
-    W->>UC: FetchInbox
-    UC->>REPO: listHeaders(folderId)
-    REPO->>GW: IMAP.fetchHeaders + LocalStore.upsert
-    REPO-->>UC: Headers
-    UC-->>UI: Headers (no UI change by default)
-  end
+  UI->>VM: inboxOpened(folderId)
+  VM->>UC: FetchInbox(folderId)
+  UC->>REPO: listHeaders(folderId)
+  REPO->>GW: IMAP.fetchHeaders + LocalStore.upsert
+  REPO-->>UC: Headers
+  UC-->>VM: Headers
+  VM-->>UI: Update state (no UX change by default)
 ```
 
 ```mermaid
@@ -178,39 +177,37 @@ sequenceDiagram
 
 ## Caching & Storage
 
-- **Bodies**: LRU by `lastOpenedAt`; **protected** items (starred/answered) never evicted. Total cap **200 MB**.
-- **Attachments**: LRU with **per‑item ≤ 100 MB**; total cap **400 MB**; too‑large items skip cache (telemetry reason=`too_large_to_cache`).
-- **Preview cache**: LRU **100** entries.
-- **Indices**: forward‑only migration for metadata queries: `date DESC`, `(from,subject)`, `(flags,date)`.
+* **Bodies**: LRU by `lastOpenedAt`; **protected** items (starred/answered) never evicted. Total cap **200 MB**.
+* **Attachments**: LRU with **per‑item ≤ 100 MB**; total cap **400 MB**; too‑large items skip cache (telemetry reason=`too_large_to_cache`).
+* **Preview cache**: LRU **100** entries.
+* **Indices**: forward‑only migration for metadata queries: `date DESC`, `(from,subject)`, `(flags,date)`.
 
 ## Performance Budgets
 
-- inbox\_open\_ms\_p50 ≤ **600ms**
-- message\_open\_ms\_p50\_cached ≤ **200ms**
-- sync\_cycle\_ms\_p50 ≤ **1500ms**
-- battery\_drain\_per\_day\_pct ≤ **2%**
-- db\_size\_mb\_cap ≤ **800MB**
+* inbox\_open\_ms\_p50 ≤ **600ms**
+* message\_open\_ms\_p50\_cached ≤ **200ms**
+* sync\_cycle\_ms\_p50 ≤ **1500ms**
+* battery\_drain\_per\_day\_pct ≤ **2%**
+* db\_size\_mb\_cap ≤ **800MB**
 
 ## Platform Considerations
 
-- **iOS background**: IMAP IDLE may be throttled. Use BGAppRefresh fallback and coalesce notifications.
-- **Network changes**: detect connectivity, re‑establish IMAP sessions with jittered backoff and circuit breaker.
+* **iOS background**: IMAP IDLE may be throttled. Use BGAppRefresh fallback and coalesce notifications.
+* **Network changes**: detect connectivity, re‑establish IMAP sessions with jittered backoff and circuit breaker.
 
 ## Testing Strategy
 
-- Unit tests for use cases, gateways (error mapping), repositories, sanitizer, caches, sync coalescing, retry/backoff.
-- Property tests for addresses/MIME decoding.
-- Scriptable IMAP fakes; golden tests for HTML rendering & RTL.
-- CI runs **unit tests only**; device/emulator CI deferred.
+* Unit tests for use cases, gateways (error mapping), repositories, sanitizer, caches, sync coalescing, retry/backoff.
+* Property tests for addresses/MIME decoding.
+* Scriptable IMAP fakes; golden tests for HTML rendering & RTL.
+* CI runs **unit tests only**; device/emulator CI deferred.
 
 ## Rollout & Kill Switch
 
-- Remote‑flagged staged rollout (planned): pilot 5% → 25% → 100%; monitor error rate <2% and budgets.
-- **Kill switch**: single remote flag `ddd.kill_switch.enabled` routes everything to **legacy**; persists across restarts.
+* Remote‑flagged staged rollout (planned): pilot 5% → 25% → 100%; monitor error rate <2% and budgets.
+* **Kill switch**: single remote flag `ddd.kill_switch.enabled` routes everything to **legacy**; persists across restarts.
 
 ## Legacy → DDD Mapping
-
-> P12.2: Controllers are thin entry points that emit telemetry and delegate to ViewModels. Widgets bind to ViewModels. P12.3 removes legacy controller orchestration and the DDD wiring shim if fully superseded.
 
 | Legacy area                      | DDD replacement                                                   |
 | -------------------------------- | ----------------------------------------------------------------- |
@@ -222,5 +219,4 @@ sequenceDiagram
 | Notifications in UI              | `features/notifications` domain + no‑op adapter (flag‑gated)      |
 | Security service                 | `features/security` keyring/trust + `CryptoEngine` stub           |
 
-> **Note:** P12.3 retired the legacy routing shim. UI binds directly to presentation ViewModels; legacy controllers are deprecated thin adapters. The kill switch still takes precedence and can force legacy paths.
-
+> **Note:** Since **P12.3**, controllers are deprecated thin adapters that delegate to **feature/presentation ViewModels**; the `shared/ddd_ui_wiring.dart` shim has been **removed**.

--- a/docs/P13_CANARY_PLAN.md
+++ b/docs/P13_CANARY_PLAN.md
@@ -1,0 +1,76 @@
+# P13 Canary Plan (no flag flips; docs + scripts)
+
+Objective
+- Prepare a safe, observable canary rollout for ViewModel-driven presentation without enabling features by default.
+- Keep ddd.send.enabled OFF. Limit ddd.search.enabled and ddd.messaging.enabled (prefetch only) to a small internal cohort.
+
+Flags and Targets
+- ddd.kill_switch.enabled: master kill; must supersede all flags.
+- ddd.search.enabled: 5% internal testers.
+- ddd.messaging.enabled (prefetch only): 5% internal testers.
+- ddd.send.enabled: OFF (0%).
+
+Cohort Strategy (internal only)
+- Limit by tester list (hashed account IDs) or by build flavor (e.g., internal QA build).
+- Example approach (app reads GetStorage):
+  - testers.allowlist: ["<hash1>", "<hash2>"]
+  - The app computes Hashing.djb2(accountEmail) and checks membership.
+
+Guardrails & Observability Checklist
+- request_id: attach to every user action (search, inbox open, send). Use stable IDs in tests.
+- error_class: ensure all failure paths map to taxonomy (AuthError, TransientNetworkError, RateLimitError, PermanentProtocolError).
+- budgets (latencies):
+  - inbox_open_ms: < 1200 ms p95 (cold open)
+  - search latency: < 1500 ms p95 (server merge allowed)
+  - attachment fetch: < 3000 ms p95 (large payloads)
+- events to watch (daily):
+  - search_success/search_failure
+  - inbox_open_ms (distribution)
+  - send_success/send_failure (send remains off for canary)
+- backpressure behavior: no crashes on network timeouts; degraded UX allowed.
+
+Instant Kill-Switch Procedure
+- If KPIs regress or error_class spikes:
+  1) Set ddd.kill_switch.enabled = true (disables all DDD routing immediately)
+  2) Confirm legacy paths are active in telemetry (path: legacy)
+  3) File incident with last request_id samples and top error_class
+
+Example: local/test toggle commands (development only)
+- The app reads GetStorage keys; during internal QA you can script a small snippet inside a debug console/test harness:
+
+  Dart snippet (debug-only):
+  ```dart
+  import 'package:get_storage/get_storage.dart';
+  import 'package:wahda_bank/shared/utils/hashing.dart';
+
+  Future<void> setCanaryFlags() async {
+    await GetStorage.init();
+    final box = GetStorage();
+    await box.write('ddd.kill_switch.enabled', false);
+    await box.write('ddd.search.enabled', true);
+    await box.write('ddd.messaging.enabled', true); // prefetch only on VM paths
+    await box.write('ddd.send.enabled', false);
+
+    // Example allowlist of hashed account IDs (internal testers only)
+    await box.write('testers.allowlist', <String>[
+      Hashing.djb2('alice.internal@wahda.com.ly').toString(),
+      Hashing.djb2('bob.internal@wahda.com.ly').toString(),
+    ]);
+  }
+  ```
+
+Rollout Steps
+- T-0: Enable canary flags to internal allowlist (5%) via build/test hooks, not in production.
+- T+1 day: Review telemetry dashboards; verify budgets and error_class distribution.
+- T+3 days: Expand to 10% internal if stable; otherwise kill-switch.
+- Do not enable ddd.send.enabled in P13.
+
+Risks
+- Unexpected IMAP load during prefetch: protected by 5% cohort, backoff/jitter remains active.
+- Legacy controller codepaths still present (deprecated) until P12.4; ensure they do not fork behavior.
+
+Exit Criteria for P13 → P14
+- p95 latencies within budgets for 3 consecutive days on canary cohort
+- search and prefetch error rates within 1.5x legacy baselines
+- no crash spikes linked to VM paths
+


### PR DESCRIPTION
P13: Canary plan (no flag flips; docs + scripts)
•  Branch: feat/ddd-p13-canary-plan
•  Changes:
•  Added docs/P13_CANARY_PLAN.md with:
◦  Cohorts: ddd.search.enabled (5% internal), ddd.messaging.enabled prefetch only (5%), ddd.send.enabled OFF
◦  Guardrails/observability (request_id, error_class, budgets)
◦  Instant kill-switch procedure
◦  Rollout steps and exit criteria
•  No code changes; docs only
•  Validation (unchanged): analyze 0 errors; tests PASS
•  Pushed: origin/feat/ddd-p13-canary-plan
•  Open PR:
•  Web link: https://github.com/dfangys/dits.ly.wahdamail/pull/new/feat/ddd-p13-canary-plan
•  Title: P13: Canary plan (no flag flips; docs + scripts)
•  Body (summary):
◦  Adds canary plan document; no code changes; pins unchanged
