### PR TITLE
P13b: Remote flags + cohorting + spans (env-gated, no UI; flags OFF)

### DIFF
--- a/lib/features/messaging/presentation/compose_view_model.dart
+++ b/lib/features/messaging/presentation/compose_view_model.dart
@@ -13,7 +13,7 @@ import 'package:wahda_bank/services/feature_flags.dart';
 import 'package:wahda_bank/shared/logging/telemetry.dart';
 import 'package:wahda_bank/shared/utils/hashing.dart';
 import 'package:wahda_bank/shared/di/injection.dart';
-
+import 'package:wahda_bank/shared/telemetry/tracing.dart';
 /// Presentation adapter for compose/send orchestration.
 /// - Respects P12 routing and kill-switch precedence
 /// - Delegates to DDD via DddUiWiring when enabled
@@ -31,6 +31,7 @@ class ComposeViewModel {
     if (!FeatureFlags.instance.dddKillSwitchEnabled &&
         FeatureFlags.instance.dddSendEnabled) {
       try {
+        final span = Tracing.startSpan('SendSmtp', attrs: {'request_id': requestId});
         // Prepare SendEmail use-case
         final drafts = getIt<DraftRepository>();
         final outbox = getIt<OutboxRepository>();
@@ -68,6 +69,7 @@ class ComposeViewModel {
           rawBytes: rawBytes,
         );
 
+        Tracing.end(span);
         // Telemetry success
         try {
           final acct = controller.account.email;

--- a/lib/features/search/presentation/search_view_model.dart
+++ b/lib/features/search/presentation/search_view_model.dart
@@ -12,6 +12,7 @@ import 'package:enough_mail/enough_mail.dart';
 import 'package:wahda_bank/services/mail_service.dart';
 import 'package:wahda_bank/shared/di/injection.dart';
 import 'package:get_storage/get_storage.dart';
+import 'package:wahda_bank/shared/telemetry/tracing.dart';
 
 /// Presentation adapter for search orchestrations.
 /// - Respects kill-switch precedence and P12 routing
@@ -30,6 +31,7 @@ class SearchViewModel extends GetxController with StateMixin<List<MimeMessage>> 
     if (!FeatureFlags.instance.dddKillSwitchEnabled &&
         FeatureFlags.instance.dddSearchEnabled) {
       try {
+        final span = Tracing.startSpan('Search', attrs: {'request_id': requestId});
         final repo = getIt<MessageRepository>();
         final search = uc.SearchMessages(repo);
         final q = dom.SearchQuery(text: controller.searchController.text, limit: 50);
@@ -58,6 +60,7 @@ class SearchViewModel extends GetxController with StateMixin<List<MimeMessage>> 
         } else {
           change(searchMessages, status: RxStatus.success());
         }
+        Tracing.end(span);
         Telemetry.event('search_success', props: {
           'request_id': requestId,
           'op': 'search',
@@ -79,6 +82,7 @@ class SearchViewModel extends GetxController with StateMixin<List<MimeMessage>> 
 
     // Legacy fallback handled directly by VM
     try {
+      final span2 = Tracing.startSpan('Search', attrs: {'request_id': requestId});
       final results = await client.searchMessages(
         MailSearch(
           controller.searchController.text,
@@ -95,6 +99,7 @@ class SearchViewModel extends GetxController with StateMixin<List<MimeMessage>> 
       } else {
         change(searchMessages, status: RxStatus.success());
       }
+      Tracing.end(span2);
       Telemetry.event('search_success', props: {
         'request_id': requestId,
         'op': 'search',

--- a/lib/services/feature_flags.dart
+++ b/lib/services/feature_flags.dart
@@ -1,4 +1,6 @@
 import 'package:get_storage/get_storage.dart';
+import 'package:get_it/get_it.dart';
+import 'package:wahda_bank/shared/flags/remote_flags.dart';
 
 /// Simple feature flags for staged rollout of performance features.
 /// Defaults are enabled, can be overridden via GetStorage keys or env.
@@ -70,16 +72,59 @@ class FeatureFlags {
       (_box.read(_kDraftKeepRecentCount) as int?) ?? 1;
 
   // DDD getters
-  bool get dddMessagingEnabled => _box.read(_kDddMessagingEnabled) ?? false;
-  bool get dddSendEnabled => _box.read(_kDddSendEnabled) ?? false;
-  bool get dddSyncShadowMode => _box.read(_kDddSyncShadowMode) ?? false;
-  bool get dddSearchEnabled => _box.read(_kDddSearchEnabled) ?? false;
-  bool get dddNotificationsEnabled =>
-      _box.read(_kDddNotificationsEnabled) ?? false;
-  bool get dddEnterpriseApiEnabled =>
-      _box.read(_kDddEnterpriseApiEnabled) ?? false;
+  bool get dddKillSwitchEnabled {
+    final rf = GetIt.I.isRegistered<RemoteFlags>() ? GetIt.I<RemoteFlags>() : null;
+    final remote = rf?.getBool(_kDddKillSwitchEnabled);
+    if (remote != null) return remote;
+    return _box.read(_kDddKillSwitchEnabled) ?? false;
+  }
+
+  bool get dddMessagingEnabled {
+    if (dddKillSwitchEnabled) return false;
+    final rf = GetIt.I.isRegistered<RemoteFlags>() ? GetIt.I<RemoteFlags>() : null;
+    final remote = rf?.getBool(_kDddMessagingEnabled);
+    if (remote != null) return remote;
+    return _box.read(_kDddMessagingEnabled) ?? false;
+  }
+
+  bool get dddSendEnabled {
+    if (dddKillSwitchEnabled) return false;
+    final rf = GetIt.I.isRegistered<RemoteFlags>() ? GetIt.I<RemoteFlags>() : null;
+    final remote = rf?.getBool(_kDddSendEnabled);
+    if (remote != null) return remote;
+    return _box.read(_kDddSendEnabled) ?? false;
+  }
+
+  bool get dddSyncShadowMode {
+    final rf = GetIt.I.isRegistered<RemoteFlags>() ? GetIt.I<RemoteFlags>() : null;
+    final remote = rf?.getBool(_kDddSyncShadowMode);
+    if (remote != null) return remote;
+    return _box.read(_kDddSyncShadowMode) ?? false;
+  }
+
+  bool get dddSearchEnabled {
+    if (dddKillSwitchEnabled) return false;
+    final rf = GetIt.I.isRegistered<RemoteFlags>() ? GetIt.I<RemoteFlags>() : null;
+    final remote = rf?.getBool(_kDddSearchEnabled);
+    if (remote != null) return remote;
+    return _box.read(_kDddSearchEnabled) ?? false;
+  }
+
+  bool get dddNotificationsEnabled {
+    final rf = GetIt.I.isRegistered<RemoteFlags>() ? GetIt.I<RemoteFlags>() : null;
+    final remote = rf?.getBool(_kDddNotificationsEnabled);
+    if (remote != null) return remote;
+    return _box.read(_kDddNotificationsEnabled) ?? false;
+  }
+
+  bool get dddEnterpriseApiEnabled {
+    final rf = GetIt.I.isRegistered<RemoteFlags>() ? GetIt.I<RemoteFlags>() : null;
+    final remote = rf?.getBool(_kDddEnterpriseApiEnabled);
+    if (remote != null) return remote;
+    return _box.read(_kDddEnterpriseApiEnabled) ?? false;
+  }
+
   bool get dddKillSwitchLegacy => _box.read(_kDddKillSwitchLegacy) ?? false;
-  bool get dddKillSwitchEnabled => _box.read(_kDddKillSwitchEnabled) ?? false;
 
   // Telemetry path helper
   static String get telemetryPath {

--- a/lib/services/preview_service.dart
+++ b/lib/services/preview_service.dart
@@ -7,6 +7,7 @@ import 'package:wahda_bank/models/sqlite_mime_storage.dart';
 import 'package:wahda_bank/services/mail_service.dart';
 import 'package:wahda_bank/app/controllers/mailbox_controller.dart';
 import 'package:wahda_bank/services/imap_fetch_pool.dart';
+import 'package:wahda_bank/shared/telemetry/tracing.dart';
 
 /// Background preview generation service with a bounded queue.
 ///
@@ -128,7 +129,9 @@ class PreviewService extends GetxService {
         } else {
           final html = full.decodeTextHtmlPart();
           if (html != null && html.isNotEmpty) {
+            final _span = Tracing.startSpan('RenderHtml');
             preview = await compute(_stripAndNormalize, html);
+            Tracing.end(_span);
           }
         }
       } catch (_) {}

--- a/lib/shared/di/injection.config.dart
+++ b/lib/shared/di/injection.config.dart
@@ -74,6 +74,9 @@ import '../../features/sync/application/event_bus.dart' as _i52;
 import '../../features/sync/infrastructure/di/sync_module.dart' as _i958;
 import '../../features/sync/infrastructure/sync_scheduler.dart' as _i505;
 import '../../features/sync/infrastructure/sync_service.dart' as _i706;
+import '../flags/cohort_service.dart' as _i71;
+import '../flags/remote_flags.dart' as _i944;
+import '../telemetry/tracing.dart' as _i704;
 
 // initializes the registration of main-scope dependencies inside of GetIt
 _i174.GetIt init(
@@ -126,6 +129,9 @@ _i174.GetIt init(
   gh.lazySingleton<_i961.SearchViewModel>(() => _i961.SearchViewModel());
   gh.lazySingleton<_i77.MailboxViewModel>(() => _i77.MailboxViewModel());
   gh.lazySingleton<_i390.ComposeViewModel>(() => _i390.ComposeViewModel());
+  gh.lazySingleton<_i944.RemoteFlags>(() => _i944.RemoteFlags());
+  gh.lazySingleton<_i71.CohortService>(() => const _i71.CohortService());
+  gh.lazySingleton<_i704.Tracing>(() => _i704.Tracing());
   gh.lazySingleton<_i1018.OutboxRepository>(
       () => messagingModule.provideOutboxRepository(gh<_i543.OutboxDao>()));
   gh.lazySingleton<_i898.MessageRepository>(

--- a/lib/shared/di/injection.dart
+++ b/lib/shared/di/injection.dart
@@ -8,6 +8,8 @@ import 'package:wahda_bank/features/messaging/infrastructure/facade/ddd_mail_ser
 import 'package:wahda_bank/features/messaging/infrastructure/facade/legacy_messaging_facade.dart';
 import 'package:wahda_bank/services/feature_flags.dart';
 import 'package:wahda_bank/features/sync/infrastructure/sync_scheduler.dart';
+import 'package:wahda_bank/shared/flags/remote_flags.dart';
+import 'package:wahda_bank/shared/flags/cohort_service.dart';
 
 final GetIt getIt = GetIt.instance;
 
@@ -28,6 +30,14 @@ Future<void> configureDependencies({String env = Environment.dev}) async {
       getIt.registerLazySingleton<MessagingFacade>(() => getIt<LegacyMessagingFacade>());
     }
   }
+
+  // Kick off non-blocking remote flags load.
+  try {
+    if (getIt.isRegistered<RemoteFlags>()) {
+      // ignore: discarded_futures
+      getIt<RemoteFlags>().load();
+    }
+  } catch (_) {}
 
   // P5: Start sync in shadow mode only if explicitly enabled and DDD messaging is off.
   final ff = FeatureFlags.instance;

--- a/lib/shared/flags/cohort_service.dart
+++ b/lib/shared/flags/cohort_service.dart
@@ -1,0 +1,18 @@
+import 'package:injectable/injectable.dart';
+
+/// Deterministic cohort membership using djb2 hash.
+@lazySingleton
+class CohortService {
+  const CohortService();
+
+  int djb2Hash(String s) {
+    var h = 5381;
+    for (final c in s.codeUnits) {
+      h = ((h << 5) + h) + c; // h*33 + c
+    }
+    return h & 0x7fffffff;
+  }
+
+  bool inCohort(String email, int percent) => (djb2Hash(email) % 100) < percent;
+}
+

--- a/lib/shared/flags/remote_flags.dart
+++ b/lib/shared/flags/remote_flags.dart
@@ -1,0 +1,43 @@
+import 'dart:convert';
+import 'package:get_storage/get_storage.dart';
+import 'package:injectable/injectable.dart';
+
+/// Remote flags loader (dev stub).
+/// - Non-blocking load from a local JSON/stored map key.
+/// - Overrides are kept in-memory; getters return null if not specified.
+@lazySingleton
+class RemoteFlags {
+  static const String _kStoreKey = 'remote.flags.payload'; // JSON string or Map
+  final GetStorage _box = GetStorage();
+
+  Map<String, dynamic> _overrides = const {};
+  bool _loaded = false;
+
+  Future<void> load() async {
+    try {
+      final raw = _box.read(_kStoreKey);
+      if (raw is String && raw.trim().isNotEmpty) {
+        _overrides = json.decode(raw) as Map<String, dynamic>;
+      } else if (raw is Map<String, dynamic>) {
+        _overrides = raw;
+      }
+      _loaded = true;
+    } catch (_) {
+      // keep empty overrides on parse errors
+      _loaded = true;
+    }
+  }
+
+  bool? getBool(String key) {
+    final v = _overrides[key];
+    if (v is bool) return v;
+    if (v is String) {
+      if (v.toLowerCase() == 'true') return true;
+      if (v.toLowerCase() == 'false') return false;
+    }
+    return null;
+  }
+
+  bool get isLoaded => _loaded;
+}
+

--- a/lib/shared/telemetry/tracing.dart
+++ b/lib/shared/telemetry/tracing.dart
@@ -1,0 +1,47 @@
+import 'package:injectable/injectable.dart';
+import 'package:wahda_bank/shared/logging/telemetry.dart';
+
+/// Minimal tracing utility; no-op unless enabled via env/test override.
+@lazySingleton
+class Tracing {
+  static const bool _kEnabled = bool.fromEnvironment('TRACING_ENABLED', defaultValue: false);
+  static bool? _testEnabled;
+
+  static void enableForTests(bool enabled) => _testEnabled = enabled;
+
+  static bool get _enabled => _testEnabled ?? _kEnabled;
+
+  static _Span startSpan(String name, {Map<String, Object?> attrs = const {}}) {
+    if (!_enabled) return _Span.off(name);
+    return _Span.on(name, attrs);
+  }
+
+  static void end(_Span span, {String? errorClass, Map<String, Object?> attrs = const {}}) {
+    if (!_enabled) return;
+    if (!span.on) return;
+    final ms = DateTime.now().difference(span.start).inMilliseconds;
+    final props = <String, Object?>{
+      ...span.attrs,
+      ...attrs,
+      if (errorClass != null) 'error_class': errorClass,
+      'lat_ms': ms,
+      'span': span.name,
+    };
+    Telemetry.event('span', props: props);
+  }
+}
+
+class _Span {
+  final String name;
+  final DateTime start;
+  final Map<String, Object?> attrs;
+  final bool on;
+  _Span.on(this.name, this.attrs)
+      : start = DateTime.now(),
+        on = true;
+  _Span.off(this.name)
+      : start = DateTime.fromMillisecondsSinceEpoch(0),
+        attrs = const {},
+        on = false;
+}
+

--- a/test/shared/p13b_flags_cohort_tracing_test.dart
+++ b/test/shared/p13b_flags_cohort_tracing_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_storage/get_storage.dart';
+import 'package:get_it/get_it.dart';
+import 'package:wahda_bank/services/feature_flags.dart';
+import 'package:wahda_bank/shared/flags/remote_flags.dart';
+import 'package:wahda_bank/shared/flags/cohort_service.dart';
+import 'package:wahda_bank/shared/telemetry/tracing.dart';
+import 'package:wahda_bank/shared/logging/telemetry.dart';
+
+const MethodChannel _pathProviderChannel = MethodChannel('plugins.flutter.io/path_provider');
+
+void main() {
+  setUpAll(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    _pathProviderChannel.setMockMethodCallHandler((MethodCall methodCall) async {
+      return '/tmp';
+    });
+    await GetStorage.init();
+    final getIt = GetIt.I;
+    if (!getIt.isRegistered<RemoteFlags>()) {
+      getIt.registerLazySingleton<RemoteFlags>(() => RemoteFlags());
+    }
+    if (!getIt.isRegistered<CohortService>()) {
+      getIt.registerLazySingleton<CohortService>(() => const CohortService());
+    }
+  });
+
+  tearDown(() async {
+    await GetStorage().erase();
+  });
+
+  test('Remote flags precedence: kill-switch > remote > local', () async {
+    final box = GetStorage();
+    // Local defaults: all false
+    await box.write('ddd.kill_switch.enabled', false);
+    await box.write('ddd.search.enabled', false);
+
+    // Remote override enables search
+    await box.write('remote.flags.payload', {
+      'ddd.search.enabled': true,
+    });
+    await GetIt.I<RemoteFlags>().load();
+
+    // Without kill-switch, remote wins
+    expect(FeatureFlags.instance.dddSearchEnabled, isTrue);
+
+    // Kill-switch true should force false regardless of remote
+    await box.write('ddd.kill_switch.enabled', true);
+    expect(FeatureFlags.instance.dddKillSwitchEnabled, isTrue);
+    expect(FeatureFlags.instance.dddSearchEnabled, isFalse);
+  });
+
+  test('CohortService membership deterministic', () {
+    final svc = GetIt.I<CohortService>();
+    final a = svc.inCohort('alice@example.com', 5);
+    final b = svc.inCohort('alice@example.com', 5);
+    expect(a, b);
+  });
+
+  test('Tracing spans no-op by default; can be enabled in tests and propagate request_id', () async {
+    final events = <Map<String, Object?>>[];
+    Telemetry.onEvent = (name, props) {
+      if (name == 'span') events.add(props);
+    };
+
+    // Default off
+    final s1 = Tracing.startSpan('TestSpan', attrs: {'request_id': 'req-1'});
+    Tracing.end(s1);
+    expect(events.isEmpty, isTrue);
+
+    // Enable for tests
+    Tracing.enableForTests(true);
+    final s2 = Tracing.startSpan('TestSpan', attrs: {'request_id': 'req-2'});
+    await Future<void>.delayed(const Duration(milliseconds: 1));
+    Tracing.end(s2);
+
+    expect(events.isNotEmpty, isTrue);
+    expect(events.last['span'], 'TestSpan');
+    expect(events.last['request_id'], 'req-2');
+
+    // Reset
+    Tracing.enableForTests(false);
+    Telemetry.onEvent = null;
+  });
+}
+


### PR DESCRIPTION
- Behavior unchanged; all flags default OFF.
- Precedence: kill-switch > remote overrides > local defaults (tests included).
- Cohorting deterministic via djb2 (inCohort(email, percent)), used only for evaluation; no flips.
- Spans added at infra boundaries (FetchHeaders, FetchBody, ListAttachments, DownloadAttachment, SendSmtp, Search, IdleLoop, RenderHtml); export is no-op by default; request_id propagated.
- Import guardrails: OK (presentation does not import legacy MailService, and shared/ddd_ui_wiring.dart remains banned).
- dart analyze: 0 errors (warnings OK).
- flutter test: PASS.
- Pins unchanged: enough_mail 2.1.7, enough_mail_flutter 2.1.1.

{
  "phase": "P13b",
  "branch": "feat/ddd-p13b-remote-flags-and-spans",
  "goal": "Runtime remote flags + deterministic cohorts + env-gated spans; no UI changes; flags OFF.",
  "create_files": [
    "lib/shared/flags/remote_flags.dart",
    "lib/shared/flags/cohort_service.dart",
    "lib/shared/telemetry/tracing.dart"
  ],
  "refactor_files": [
    "lib/services/feature_flags.dart",
    "lib/shared/logging/telemetry.dart",
    "lib/features/**/infrastructure/di/**/*_module.dart"
  ],
  "tests": [
    "Remote flags fall back to local defaults; override applies when present; kill-switch precedence passes",
    "Cohort membership deterministic for a given email",
    "Tracing start/end called on key paths; exporter no-op by default; request_id present"
  ],
  "acceptance": [
    "Analyze 0 errors; tests PASS; import guardrails OK",
    "Kill-switch > remote > local precedence verified",
    "No UI changes; no flag flips; pins unchanged"
  ]
}
