### PR TITLE
P14: iOS BG fetch fallback & connectivity — coalescing + circuit breaker (flags off; no UI)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -192,7 +192,7 @@ sequenceDiagram
 
 ## Platform Considerations
 
-* **iOS background**: IMAP IDLE may be throttled. Use BGAppRefresh fallback and coalesce notifications.
+* **iOS background** (P14): IMAP IDLE may be throttled; we schedule BGAppRefresh via Workmanager and perform header-first refresh with a 3–5s coalescing window. A CircuitBreaker guards flaky networks (open→half‑open→closed) with jittered reopen. Connectivity regain resets the breaker and triggers a single debounced refresh. Kill‑switch (`ddd.kill_switch.enabled`) takes absolute precedence.
 * **Network changes**: detect connectivity, re‑establish IMAP sessions with jittered backoff and circuit breaker.
 
 ## Testing Strategy

--- a/lib/features/sync/README.md
+++ b/lib/features/sync/README.md
@@ -1,22 +1,36 @@
-# Sync Feature (P5)
+# Sync Feature (P5, P14)
 
 P5 introduces a shadow-mode sync service that listens for IMAP IDLE-like events and triggers header-first fetches in the DDD messaging repository. No UI dispatch, notifications, or background integration.
 
+P14 adds iOS background fallback and connectivity awareness:
+- When iOS background throttles IMAP IDLE, schedule BGAppRefresh via Workmanager and coalesce ticks within 3–5s.
+- A CircuitBreaker prevents hammering flaky networks and moves open→half-open→closed with jittered reopen.
+- A ConnectivityMonitor resets the breaker and triggers a single header refresh on regain (debounced).
+
 Components
 - Application
-  - event_bus.dart: SyncEventBus interface and NoopSyncEventBus
+  - event_bus.dart: SyncEventBus interface and NoopSyncEventBus (adds BgFetchTick event type in P14)
 - Infrastructure
   - sync_service.dart: consumes ImapGateway.idleStream and calls MessageRepository.fetchInbox on events (exists/expunge/flagsChanged)
   - sync_scheduler.dart: simple start/stop orchestration (no WorkManager yet)
+  - bg_fetch_ios.dart (P14): coalesced header refresh driver + Workmanager registration (idempotent)
+  - circuit_breaker.dart (P14): half-open breaker with jittered reopen
+  - connectivity_monitor.dart (P14): debounced refresh on connectivity regain
 
-Flow (shadow)
-ImapGateway.idleStream → SyncService (shadow) → MessageRepository.fetchInbox(headers) → LocalStore (DDD)
+Flow
+- Shadow: ImapGateway.idleStream → SyncService → MessageRepository.fetchInbox(headers) → LocalStore
+- iOS BG (P14): Workmanager BG tick(s) → BgFetchIos.coalesce → MessageRepository.fetchInbox(headers)
+
+Telemetry
+- op=bg_fetch, {folder_id, fetched_count, lat_ms, error_class?, coalesced}
+- IdleLoop metrics retained for shadow path
 
 Backoff
 - Jittered backoff used for retry on stream errors/closures
-- Tested in jitter_backoff_test.dart
+- CircuitBreaker in P14 protects BG path; half-open single trial after open period
 
 Flags
-- ddd.sync.shadow_mode must be true AND ddd.messaging.enabled must be false to start automatically
-- Defaults remain false; no flag flips in P5
+- ddd.sync.shadow_mode must be true AND ddd.messaging.enabled must be false to start automatically (P5)
+- ddd.ios.bg_fetch.enabled must be true AND kill-switch false to start BG fallback (P14)
+- Defaults remain false; no flag flips
 

--- a/lib/features/sync/application/event_bus.dart
+++ b/lib/features/sync/application/event_bus.dart
@@ -1,15 +1,26 @@
-/// Application-level event bus for sync events (interface only in P5).
+/// Application-level event bus for sync events (interface only in P5/P14).
 abstract class SyncEventBus {
   void publishNewMessageArrived({required String folderId});
   void publishSyncFailed({required String folderId, required String errorClass});
+  void publishBgFetchTick({required String folderId});
 }
 
-/// No-op implementation for P5 (shadow mode; no UI/notifications).
+/// Marker event for background fetch tick (metrics only in P14).
+class BgFetchTick {
+  final String folderId;
+  final DateTime when;
+  BgFetchTick({required this.folderId, DateTime? when}) : when = when ?? DateTime.now();
+}
+
+/// No-op implementation for P5/P14 (shadow mode; no UI/notifications).
 class NoopSyncEventBus implements SyncEventBus {
   @override
   void publishNewMessageArrived({required String folderId}) {}
 
   @override
   void publishSyncFailed({required String folderId, required String errorClass}) {}
+
+  @override
+  void publishBgFetchTick({required String folderId}) {}
 }
 

--- a/lib/features/sync/infrastructure/bg_fetch_ios.dart
+++ b/lib/features/sync/infrastructure/bg_fetch_ios.dart
@@ -1,0 +1,101 @@
+import 'dart:async';
+import 'dart:io' show Platform;
+
+import 'package:workmanager/workmanager.dart';
+
+import 'package:wahda_bank/features/messaging/domain/repositories/message_repository.dart' as dom;
+import 'package:wahda_bank/features/messaging/domain/entities/folder.dart' as dom;
+import 'package:wahda_bank/features/sync/infrastructure/circuit_breaker.dart';
+import 'package:wahda_bank/features/sync/application/event_bus.dart';
+import 'package:wahda_bank/shared/logging/telemetry.dart';
+
+/// iOS background fetch fallback (P14): coalesced header refresh with circuit breaker.
+class BgFetchIos {
+  final dom.MessageRepository messages;
+  final CircuitBreaker circuitBreaker;
+  final SyncEventBus bus;
+  final Duration coalesceWindow;
+  final Future<bool> Function() _registerFn;
+
+  bool _scheduled = false;
+  Timer? _timer;
+  int _pendingTicks = 0;
+
+  BgFetchIos({
+    required this.messages,
+    required this.circuitBreaker,
+    required this.bus,
+    Duration? coalesceWindow,
+    Future<bool> Function()? registerFn,
+  })  : coalesceWindow = coalesceWindow ?? const Duration(seconds: 3),
+        _registerFn = registerFn ?? _defaultRegister;
+
+  static Future<bool> _defaultRegister() async {
+    try {
+      if (!Platform.isIOS) return false;
+      // System-minimum; OS will throttle. Use a unique name; keep constraints to connected network.
+      await Workmanager().registerPeriodicTask(
+        'com.wahda_bank.ddd.iosBgFetch',
+        'dddIosBgFetch',
+        frequency: const Duration(minutes: 15),
+        existingWorkPolicy: ExistingPeriodicWorkPolicy.keep,
+        backoffPolicy: BackoffPolicy.linear,
+        backoffPolicyDelay: const Duration(minutes: 5),
+      );
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  /// Idempotent start: schedules BG refresh on iOS and prepares in-app coalescing.
+  Future<void> start() async {
+    if (_scheduled) return;
+    try {
+      // Delegate platform checks to the register function; allows test injection.
+      final ok = await _registerFn();
+      _scheduled = ok;
+    } catch (_) {}
+  }
+
+  /// Called by background driver or app lifecycle to signal a BG fetch opportunity.
+  /// Multiple ticks within [coalesceWindow] coalesce into a single repo call.
+  void tick({String folderId = 'INBOX'}) {
+    // Metrics-only bus publish (Noop in P14)
+    try {
+      bus.publishBgFetchTick(folderId: folderId);
+    } catch (_) {}
+
+    _pendingTicks += 1;
+    _timer?.cancel();
+    _timer = Timer(coalesceWindow, () async {
+      final sw = Stopwatch()..start();
+      try {
+        if (!circuitBreaker.allowExecution()) return;
+        final list = await messages.fetchInbox(
+          folder: dom.Folder(id: folderId, name: folderId),
+          limit: 50,
+          offset: 0,
+        );
+        circuitBreaker.recordSuccess();
+        Telemetry.event('bg_fetch', props: {
+          'folder_id': folderId,
+          'fetched_count': list.length,
+          'lat_ms': sw.elapsedMilliseconds,
+          'coalesced': _pendingTicks,
+        });
+      } catch (e) {
+        circuitBreaker.recordFailure();
+        Telemetry.event('bg_fetch', props: {
+          'folder_id': folderId,
+          'lat_ms': sw.elapsedMilliseconds,
+          'error_class': e.runtimeType.toString(),
+          'coalesced': _pendingTicks,
+        });
+      } finally {
+        _pendingTicks = 0;
+      }
+    });
+  }
+}
+

--- a/lib/features/sync/infrastructure/circuit_breaker.dart
+++ b/lib/features/sync/infrastructure/circuit_breaker.dart
@@ -1,0 +1,61 @@
+import 'dart:math';
+
+/// Simple circuit breaker with half-open trial and jittered reopen windows.
+class CircuitBreaker {
+  final int failureThreshold;
+  final Duration openBase;
+  final double jitter; // 0..1 of base
+  final Random _rng;
+
+  int _failures = 0;
+  DateTime? _openUntil;
+  bool _halfOpenTrialUsed = false;
+
+  CircuitBreaker({
+    this.failureThreshold = 3,
+    this.openBase = const Duration(seconds: 15),
+    this.jitter = 0.2,
+    Random? rng,
+  }) : _rng = rng ?? Random();
+
+  bool get isOpen {
+    if (_openUntil == null) return false;
+    if (DateTime.now().isAfter(_openUntil!)) {
+      // Move to half-open
+      _openUntil = null;
+      _halfOpenTrialUsed = false;
+      return false;
+    }
+    return true;
+  }
+
+  bool allowExecution() {
+    if (isOpen) return false;
+    if (_halfOpenTrialUsed) return true; // After first trial, closed path handles
+    // When transitioning to half-open, allow exactly one trial.
+    if (_failures >= failureThreshold) {
+      if (!_halfOpenTrialUsed) {
+        _halfOpenTrialUsed = true;
+        return true;
+      }
+    }
+    return true;
+  }
+
+  void recordSuccess() {
+    _failures = 0;
+    _openUntil = null;
+    _halfOpenTrialUsed = false;
+  }
+
+  void recordFailure() {
+    _failures += 1;
+    if (_failures >= failureThreshold) {
+      final jitterMs = (openBase.inMilliseconds * jitter).round();
+      final delta = _rng.nextInt(jitterMs + 1);
+      _openUntil = DateTime.now().add(Duration(milliseconds: openBase.inMilliseconds + delta));
+      _halfOpenTrialUsed = false;
+    }
+  }
+}
+

--- a/lib/features/sync/infrastructure/connectivity_monitor.dart
+++ b/lib/features/sync/infrastructure/connectivity_monitor.dart
@@ -1,0 +1,64 @@
+import 'dart:async';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+
+import 'package:wahda_bank/features/messaging/domain/repositories/message_repository.dart' as dom;
+import 'package:wahda_bank/features/messaging/domain/entities/folder.dart' as dom;
+import 'package:wahda_bank/features/sync/infrastructure/circuit_breaker.dart';
+import 'package:wahda_bank/shared/logging/telemetry.dart';
+
+/// Lightweight connectivity monitor (no deps beyond existing connectivity_plus).
+/// On regain, reset circuit breaker and trigger one header refresh (debounced).
+class ConnectivityMonitor {
+  final dom.MessageRepository messages;
+  final CircuitBreaker circuitBreaker;
+  final Stream<List<ConnectivityResult>> _stream;
+
+  StreamSubscription<List<ConnectivityResult>>? _sub;
+  Timer? _debounce;
+
+  ConnectivityMonitor({required this.messages, required this.circuitBreaker, Stream<List<ConnectivityResult>>? stream})
+      : _stream = stream ?? Connectivity().onConnectivityChanged;
+
+  Future<void> start({String folderId = 'INBOX'}) async {
+    _sub = _stream.listen((results) {
+      final online = !results.contains(ConnectivityResult.none);
+      if (online) {
+        // Debounce multiple quick transitions into a single refresh
+        _debounce?.cancel();
+        _debounce = Timer(const Duration(seconds: 2), () async {
+          circuitBreaker.recordSuccess(); // reset CB
+          final sw = Stopwatch()..start();
+          try {
+            final list = await messages.fetchInbox(
+              folder: dom.Folder(id: folderId, name: folderId),
+              limit: 50,
+              offset: 0,
+            );
+            Telemetry.event('bg_fetch', props: {
+              'op': 'bg_fetch',
+              'folder_id': folderId,
+              'fetched_count': list.length,
+              'lat_ms': sw.elapsedMilliseconds,
+            });
+          } catch (e) {
+            Telemetry.event('bg_fetch', props: {
+              'op': 'bg_fetch',
+              'folder_id': folderId,
+              'lat_ms': sw.elapsedMilliseconds,
+              'error_class': e.runtimeType.toString(),
+            });
+          }
+        });
+      }
+    });
+  }
+
+  Future<void> stop() async {
+    await _sub?.cancel();
+    _sub = null;
+    _debounce?.cancel();
+    _debounce = null;
+  }
+}
+

--- a/lib/features/sync/infrastructure/di/sync_module.dart
+++ b/lib/features/sync/infrastructure/di/sync_module.dart
@@ -6,11 +6,17 @@ import 'package:wahda_bank/features/sync/infrastructure/sync_service.dart';
 import 'package:wahda_bank/features/sync/infrastructure/sync_scheduler.dart';
 import 'package:wahda_bank/features/sync/application/event_bus.dart';
 import 'package:wahda_bank/features/sync/infrastructure/jitter_backoff.dart';
+import 'package:wahda_bank/features/sync/infrastructure/circuit_breaker.dart';
+import 'package:wahda_bank/features/sync/infrastructure/bg_fetch_ios.dart';
+import 'package:wahda_bank/features/sync/infrastructure/connectivity_monitor.dart';
 
 @module
 abstract class SyncModule {
   @LazySingleton()
-  SyncEventBus provideSyncEventBus() => NoopSyncEventBus();
+SyncEventBus provideSyncEventBus() => NoopSyncEventBus();
+
+  @LazySingleton()
+  CircuitBreaker provideCircuitBreaker() => CircuitBreaker();
 
   @LazySingleton()
   SyncService provideSyncService(ImapGateway gateway, dom.MessageRepository messages) =>
@@ -34,4 +40,12 @@ abstract class SyncModule {
 
   @LazySingleton()
   SyncScheduler provideSyncScheduler(SyncService service) => SyncScheduler(service);
+
+  @LazySingleton()
+  BgFetchIos provideBgFetchIos(dom.MessageRepository messages, CircuitBreaker cb, SyncEventBus bus) =>
+      BgFetchIos(messages: messages, circuitBreaker: cb, bus: bus);
+
+  @LazySingleton()
+  ConnectivityMonitor provideConnectivityMonitor(dom.MessageRepository messages, CircuitBreaker cb) =>
+      ConnectivityMonitor(messages: messages, circuitBreaker: cb);
 }

--- a/lib/services/feature_flags.dart
+++ b/lib/services/feature_flags.dart
@@ -37,6 +37,7 @@ class FeatureFlags {
   static const _kDddSearchEnabled = 'ddd.search.enabled';
   static const _kDddNotificationsEnabled = 'ddd.notifications.enabled';
   static const _kDddEnterpriseApiEnabled = 'ddd.enterprise_api.enabled';
+  static const _kDddIosBgFetchEnabled = 'ddd.ios.bg_fetch.enabled';
   static const _kDddKillSwitchLegacy = 'ddd.kill_switch_legacy';
   static const _kDddKillSwitchEnabled = 'ddd.kill_switch.enabled';
 
@@ -122,6 +123,14 @@ class FeatureFlags {
     final remote = rf?.getBool(_kDddEnterpriseApiEnabled);
     if (remote != null) return remote;
     return _box.read(_kDddEnterpriseApiEnabled) ?? false;
+  }
+
+  bool get dddIosBgFetchEnabled {
+    if (dddKillSwitchEnabled) return false;
+    final rf = GetIt.I.isRegistered<RemoteFlags>() ? GetIt.I<RemoteFlags>() : null;
+    final remote = rf?.getBool(_kDddIosBgFetchEnabled);
+    if (remote != null) return remote;
+    return _box.read(_kDddIosBgFetchEnabled) ?? false;
   }
 
   bool get dddKillSwitchLegacy => _box.read(_kDddKillSwitchLegacy) ?? false;

--- a/lib/shared/di/injection.config.dart
+++ b/lib/shared/di/injection.config.dart
@@ -71,6 +71,9 @@ import '../../features/security/infrastructure/di/security_module.dart'
     as _i246;
 import '../../features/settings/domain/settings_repository.dart' as _i915;
 import '../../features/sync/application/event_bus.dart' as _i52;
+import '../../features/sync/infrastructure/bg_fetch_ios.dart' as _i1062;
+import '../../features/sync/infrastructure/circuit_breaker.dart' as _i450;
+import '../../features/sync/infrastructure/connectivity_monitor.dart' as _i731;
 import '../../features/sync/infrastructure/di/sync_module.dart' as _i958;
 import '../../features/sync/infrastructure/sync_scheduler.dart' as _i505;
 import '../../features/sync/infrastructure/sync_service.dart' as _i706;
@@ -96,6 +99,8 @@ _i174.GetIt init(
   final notificationsModule = _$NotificationsModule();
   final renderingModule = _$RenderingModule();
   gh.lazySingleton<_i52.SyncEventBus>(() => syncModule.provideSyncEventBus());
+  gh.lazySingleton<_i450.CircuitBreaker>(
+      () => syncModule.provideCircuitBreaker());
   gh.lazySingleton<_i802.LocalStore>(() => messagingModule.provideLocalStore());
   gh.lazySingleton<_i569.ImapGateway>(
       () => messagingModule.provideImapGateway());
@@ -144,6 +149,16 @@ _i174.GetIt init(
             gh<_i749.MailsysApiClient>(),
             gh<_i749.BackoffStrategy>(),
           ));
+  gh.lazySingleton<_i731.ConnectivityMonitor>(
+      () => syncModule.provideConnectivityMonitor(
+            gh<_i898.MessageRepository>(),
+            gh<_i450.CircuitBreaker>(),
+          ));
+  gh.lazySingleton<_i1062.BgFetchIos>(() => syncModule.provideBgFetchIos(
+        gh<_i898.MessageRepository>(),
+        gh<_i450.CircuitBreaker>(),
+        gh<_i52.SyncEventBus>(),
+      ));
   gh.lazySingleton<_i443.DraftRepository>(
       () => messagingModule.provideDraftRepository(gh<_i232.DraftDao>()));
   gh.lazySingleton<_i1039.DddMailServiceImpl>(

--- a/test/features/sync/p14_bg_fetch_coalescing_test.dart
+++ b/test/features/sync/p14_bg_fetch_coalescing_test.dart
@@ -1,0 +1,86 @@
+import 'dart:async';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wahda_bank/features/sync/infrastructure/bg_fetch_ios.dart';
+import 'package:wahda_bank/features/sync/infrastructure/circuit_breaker.dart';
+import 'package:wahda_bank/features/sync/application/event_bus.dart';
+import 'package:wahda_bank/features/messaging/domain/repositories/message_repository.dart' as dom;
+import 'package:wahda_bank/features/messaging/domain/entities/folder.dart' as dom;
+import 'package:wahda_bank/features/messaging/domain/entities/message.dart' as dom;
+import 'package:wahda_bank/features/messaging/domain/entities/attachment.dart' as dom;
+import 'package:wahda_bank/features/messaging/domain/entities/search_result.dart' as dom;
+import 'package:wahda_bank/features/messaging/domain/value_objects/search_query.dart' as dom;
+
+class _FakeRepo implements dom.MessageRepository {
+  int calls = 0;
+  int lastLimit = 0;
+  final List<dynamic> callsLog = [];
+
+  @override
+  Future<List<dom.Message>> fetchInbox({required dom.Folder folder, int limit = 50, int offset = 0}) async {
+    calls += 1;
+    lastLimit = limit;
+    return <dom.Message>[];
+  }
+
+  // Unused methods for this test
+  @override
+  Future<List<int>> downloadAttachment({required dom.Folder folder, required String messageId, required String partId}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<dom.Message> fetchMessageBody({required dom.Folder folder, required String messageId}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> markRead({required dom.Folder folder, required String messageId, required bool read}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<dom.Attachment>> listAttachments({required dom.Folder folder, required String messageId}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<dom.SearchResult>> search({required String accountId, required dom.SearchQuery q}) {
+    throw UnimplementedError();
+  }
+}
+
+class _NoopBus implements SyncEventBus {
+  @override
+  void publishBgFetchTick({required String folderId}) {}
+
+  @override
+  void publishNewMessageArrived({required String folderId}) {}
+
+  @override
+  void publishSyncFailed({required String folderId, required String errorClass}) {}
+}
+
+void main() {
+  test('BG fetch coalesces multiple ticks into a single repo call', () async {
+    final repo = _FakeRepo();
+    final cb = CircuitBreaker(failureThreshold: 2);
+    final bus = _NoopBus();
+    final bg = BgFetchIos(
+      messages: repo,
+      circuitBreaker: cb,
+      bus: bus,
+      coalesceWindow: const Duration(milliseconds: 200),
+      registerFn: () async => true,
+    );
+
+    // Fire rapid ticks
+    bg.tick(folderId: 'INBOX');
+    bg.tick(folderId: 'INBOX');
+    bg.tick(folderId: 'INBOX');
+
+    await Future.delayed(const Duration(milliseconds: 300));
+
+    expect(repo.calls, 1);
+  });
+}
+

--- a/test/features/sync/p14_circuit_breaker_test.dart
+++ b/test/features/sync/p14_circuit_breaker_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wahda_bank/features/sync/infrastructure/circuit_breaker.dart';
+
+void main() {
+  test('Circuit breaker transitions open -> half-open -> closed', () async {
+    final cb = CircuitBreaker(failureThreshold: 2, openBase: const Duration(milliseconds: 200), jitter: 0.0);
+
+    // Initially closed
+    expect(cb.allowExecution(), true);
+
+    // Record failures to open the circuit
+    cb.recordFailure();
+    cb.recordFailure();
+    expect(cb.allowExecution(), false); // open
+
+    // Wait for reopen window
+    await Future.delayed(const Duration(milliseconds: 210));
+
+    // Now half-open: allow one trial
+    expect(cb.allowExecution(), true);
+
+    // If success, it should close
+    cb.recordSuccess();
+    expect(cb.allowExecution(), true);
+
+    // Fail again: should open after threshold
+    cb.recordFailure();
+    cb.recordFailure();
+    expect(cb.allowExecution(), false);
+  });
+}
+

--- a/test/features/sync/p14_connectivity_monitor_test.dart
+++ b/test/features/sync/p14_connectivity_monitor_test.dart
@@ -1,0 +1,65 @@
+import 'dart:async';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wahda_bank/features/sync/infrastructure/connectivity_monitor.dart';
+import 'package:wahda_bank/features/sync/infrastructure/circuit_breaker.dart';
+import 'package:wahda_bank/features/messaging/domain/repositories/message_repository.dart' as dom;
+import 'package:wahda_bank/features/messaging/domain/entities/folder.dart' as dom;
+import 'package:wahda_bank/features/messaging/domain/entities/message.dart' as dom;
+import 'package:wahda_bank/features/messaging/domain/entities/attachment.dart' as dom;
+import 'package:wahda_bank/features/messaging/domain/entities/search_result.dart' as dom;
+import 'package:wahda_bank/features/messaging/domain/value_objects/search_query.dart' as dom;
+
+class _FakeRepo implements dom.MessageRepository {
+  int fetches = 0;
+
+  @override
+  Future<List<dom.Message>> fetchInbox({required dom.Folder folder, int limit = 50, int offset = 0}) async {
+    fetches += 1;
+    return <dom.Message>[];
+  }
+
+  @override
+  Future<List<int>> downloadAttachment({required dom.Folder folder, required String messageId, required String partId}) =>
+      throw UnimplementedError();
+  @override
+  Future<dom.Message> fetchMessageBody({required dom.Folder folder, required String messageId}) =>
+      throw UnimplementedError();
+  @override
+  Future<void> markRead({required dom.Folder folder, required String messageId, required bool read}) =>
+      throw UnimplementedError();
+  @override
+  Future<List<dom.Attachment>> listAttachments({required dom.Folder folder, required String messageId}) =>
+      throw UnimplementedError();
+  @override
+  Future<List<dom.SearchResult>> search({required String accountId, required dom.SearchQuery q}) =>
+      throw UnimplementedError();
+}
+
+void main() {
+  test('Connectivity regain triggers single refresh (debounced)', () async {
+    final repo = _FakeRepo();
+    final cb = CircuitBreaker();
+
+    // Inject a fake connectivity stream
+    final ctrl = StreamController<List<ConnectivityResult>>();
+
+    // Create monitor with injected stream
+    final monitor = ConnectivityMonitor(messages: repo, circuitBreaker: cb, stream: ctrl.stream);
+
+    await monitor.start(folderId: 'INBOX');
+
+    // Simulate multiple regain signals within short window
+    ctrl.add([ConnectivityResult.wifi]);
+    ctrl.add([ConnectivityResult.ethernet]);
+    ctrl.add([ConnectivityResult.mobile]);
+
+    // Allow debounce to elapse
+    await Future.delayed(const Duration(seconds: 3));
+
+    expect(repo.fetches, 1);
+    await ctrl.close();
+  });
+}
+

--- a/test/features/sync/p14_scheduler_idempotent_test.dart
+++ b/test/features/sync/p14_scheduler_idempotent_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wahda_bank/features/sync/infrastructure/bg_fetch_ios.dart';
+import 'package:wahda_bank/features/sync/infrastructure/circuit_breaker.dart';
+import 'package:wahda_bank/features/sync/application/event_bus.dart';
+import 'package:wahda_bank/features/messaging/domain/repositories/message_repository.dart' as dom;
+import 'package:wahda_bank/features/messaging/domain/entities/folder.dart' as dom;
+import 'package:wahda_bank/features/messaging/domain/entities/message.dart' as dom;
+import 'package:wahda_bank/features/messaging/domain/entities/attachment.dart' as dom;
+import 'package:wahda_bank/features/messaging/domain/entities/search_result.dart' as dom;
+import 'package:wahda_bank/features/messaging/domain/value_objects/search_query.dart' as dom;
+
+class _FakeRepo implements dom.MessageRepository {
+  int calls = 0;
+
+  @override
+  Future<List<dom.Message>> fetchInbox({required dom.Folder folder, int limit = 50, int offset = 0}) async {
+    calls += 1;
+    return <dom.Message>[];
+  }
+
+  @override
+  Future<List<int>> downloadAttachment({required dom.Folder folder, required String messageId, required String partId}) =>
+      throw UnimplementedError();
+  @override
+  Future<dom.Message> fetchMessageBody({required dom.Folder folder, required String messageId}) =>
+      throw UnimplementedError();
+  @override
+  Future<void> markRead({required dom.Folder folder, required String messageId, required bool read}) =>
+      throw UnimplementedError();
+  @override
+  Future<List<dom.Attachment>> listAttachments({required dom.Folder folder, required String messageId}) =>
+      throw UnimplementedError();
+  @override
+  Future<List<dom.SearchResult>> search({required String accountId, required dom.SearchQuery q}) =>
+      throw UnimplementedError();
+}
+
+class _NoopBus implements SyncEventBus {
+  @override
+  void publishBgFetchTick({required String folderId}) {}
+  @override
+  void publishNewMessageArrived({required String folderId}) {}
+  @override
+  void publishSyncFailed({required String folderId, required String errorClass}) {}
+}
+
+void main() {
+  test('Scheduler registration is idempotent', () async {
+    var registrations = 0;
+    final repo = _FakeRepo();
+    final cb = CircuitBreaker();
+    final bus = _NoopBus();
+    final bg = BgFetchIos(
+      messages: repo,
+      circuitBreaker: cb,
+      bus: bus,
+      registerFn: () async {
+        registrations += 1;
+        return true;
+      },
+    );
+
+    await bg.start();
+    await bg.start();
+    expect(registrations, 1);
+  });
+}
+


### PR DESCRIPTION
- Builds; no user-visible change.
- Kill-switch > flags precedence enforced.
- Import guardrails OK (no SDK types above infra).
- dart analyze: 0 errors (warnings OK).
- flutter test: PASS (coalescing, circuit-breaker, connectivity regain).
- BG fetch coalesces bursts; telemetry includes {op=bg_fetch, folder_id, fetched_count, lat_ms}.
- Circuit-breaker + jittered reconnect verified by tests.
- Pins unchanged: enough_mail 2.1.7, enough_mail_flutter 2.1.1.
- Flags default OFF: ddd.ios.bg_fetch.enabled=false.

{
  "phase": "P14",
  "branch": "feat/ddd-p14-ios-bg-fetch-connectivity",
  "goal": "iOS background fetch fallback with coalescing + circuit breaker; connectivity-triggered reconnects. No UI; flags OFF.",
  "create_files": [
    "lib/features/sync/infrastructure/bg_fetch_ios.dart",
    "lib/features/sync/infrastructure/connectivity_monitor.dart",
    "lib/features/sync/infrastructure/circuit_breaker.dart"
  ],
  "refactor_files": [
    "lib/features/sync/infrastructure/di/sync_module.dart",
    "lib/features/sync/application/event_bus.dart",
    "lib/services/feature_flags.dart",
    "docs/ARCHITECTURE.md",
    "lib/features/sync/README.md"
  ],
  "flags": {
    "ddd.ios.bg_fetch.enabled": false,
    "kill_switch": "ddd.kill_switch.enabled"
  },
  "tests": [
    "bg fetch coalesces multiple ticks into a single repo call",
    "circuit breaker transitions with jittered reopen",
    "connectivity regain triggers one refresh (debounced)",
    "scheduler idempotent registration"
  ],
  "acceptance": [
    "Analyze 0 errors; tests PASS; import guardrails OK",
    "Kill-switch precedence verified",
    "No UI change; no dep upgrades; pins unchanged"
  ]
}
