### PR TITLE
P16b: Enable canary cohorts (remote flags only; send OFF; kill-switch honored)

### DIFF
--- a/docs/P13_CANARY_PLAN.md
+++ b/docs/P13_CANARY_PLAN.md
@@ -122,6 +122,14 @@ Rollout Steps
 - T+3 days: Expand to 10% internal if stable; otherwise kill-switch.
 - Do not enable ddd.send.enabled in P13.
 
+Execution Log (P16b)
+- 2025-09-03T15:08:00Z: Planned enable via remote flags only (no app default changes)
+  - ddd.search.enabled: 5% internal cohort (djb2(email)%100 < 5)
+  - ddd.messaging.enabled (prefetch only): 5% internal cohort (djb2(email)%100 < 5)
+  - ddd.send.enabled: OFF (0%)
+  - Kill-switch highlighted: flip ddd.kill_switch.enabled=true for immediate rollback
+  - Script reference: scripts/canary/enable_internal_5_percent.sh (illustrative, replace with real API)
+
 Risks
 - Unexpected IMAP load during prefetch: protected by 5% cohort, backoff/jitter remains active.
 - Legacy controller codepaths still present (deprecated) until P12.4; ensure they do not fork behavior.

--- a/scripts/canary/enable_internal_5_percent.sh
+++ b/scripts/canary/enable_internal_5_percent.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# scripts/canary/enable_internal_5_percent.sh
+# Purpose: Enable 5% internal canary cohorts via remote flags (no app default changes).
+# Usage: export REMOTE_FLAGS_ENDPOINT={{your_endpoint}} and AUTH={{token}} or adapt the curl calls below.
+# NOTE: This script is illustrative; adapt to your remote flag service.
+
+set -euo pipefail
+
+NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+SEARCH_PERCENT=5
+MESSAGING_PREFETCH_PERCENT=5
+SEND_PERCENT=0
+KILL_SWITCH_KEY="ddd.kill_switch.enabled"
+
+# Deterministic cohort helper (djb2) in awk for quick targeting if your service accepts server-side rules
+# Example condition (pseudocode): djb2(email) % 100 < PERCENT and email in internal domain
+
+# Replace the following with your remote flag update API calls.
+# Here we just echo the intended ops for auditing.
+echo "[$NOW] Plan: set ddd.search.enabled to ${SEARCH_PERCENT}% internal cohort"
+echo "[$NOW] Plan: set ddd.messaging.enabled (prefetch only) to ${MESSAGING_PREFETCH_PERCENT}% internal cohort"
+echo "[$NOW] Plan: keep ddd.send.enabled at ${SEND_PERCENT}% (OFF)"
+echo "[$NOW] Kill-switch key: ${KILL_SWITCH_KEY} (one-flip rollback)"
+
+echo "[$NOW] Example ops (replace with real API):"
+echo "curl -X POST $REMOTE_FLAGS_ENDPOINT/flags/ddd.search.enabled -H 'Authorization: Bearer $AUTH' -H 'Content-Type: application/json' \
+  -d '{\"rule\": \"internal && (djb2(email)%100 < ${SEARCH_PERCENT})\"}'"
+
+echo "curl -X POST $REMOTE_FLAGS_ENDPOINT/flags/ddd.messaging.enabled -H 'Authorization: Bearer $AUTH' -H 'Content-Type: application/json' \
+  -d '{\"rule\": \"internal && (djb2(email)%100 < ${MESSAGING_PREFETCH_PERCENT})\"}'"
+
+echo "curl -X POST $REMOTE_FLAGS_ENDPOINT/flags/ddd.send.enabled -H 'Authorization: Bearer $AUTH' -H 'Content-Type: application/json' \
+  -d '{\"fixed\": false}'"
+
+echo "[$NOW] To rollback immediately: set ${KILL_SWITCH_KEY}=true"
+


### PR DESCRIPTION
Scope
- Remote flags only (no app default changes) to enable 5% internal cohorts:
  - ddd.search.enabled → 5%
  - ddd.messaging.enabled (prefetch only) → 5%
  - ddd.send.enabled → OFF (0%)
- Deterministic cohort helper (djb2) as documented; app defaults unchanged.
- Added ops script: scripts/canary/enable_internal_5_percent.sh (illustrative; replace with real API).
- docs/P13_CANARY_PLAN.md: Added Execution Log with timestamp, cohorts, and rollback steps.
- Kill-switch remains the single-flip rollback (ddd.kill_switch.enabled).

Validation
- dart run tool/import_enforcer.dart → OK
- dart analyze → 0 errors (warnings OK)
- flutter test --no-pub test → PASS

Acceptance
- No code-path changes; only docs + scripts + ops notes
- Defaults in code unchanged; kill-switch unmodified
- Guardrails pass; analyze 0 errors; tests PASS

Tiny JSON slice
