### PR TITLE
P28: Background perf sampling — sync/idle & bg_fetch (no feature change)

### DIFF
--- a/docs/P25_PERF_SAMPLING.md
+++ b/docs/P25_PERF_SAMPLING.md
@@ -85,3 +85,23 @@ P27: Message detail render & scroll (no feature change)
 - How to run:
   flutter run -d <device> | dart run scripts/perf/parse_frame_timings.dart
 
+---
+
+P28: Background perf sampling — sync/idle & bg_fetch (no feature change)
+- Sampler: lib/observability/perf/bg_perf_sampler.dart
+  - Ops: idle_loop (IMAP IDLE alive), fetch_headers_batch (header batch), bg_fetch_ios_cycle (iOS BG fallback), reconnect_window (connectivity regain coalesced refresh)
+  - Fields: op, latency_ms, jank_frames, total_frames, dropped_pct, request_id (optional)
+- Hooks:
+  - SyncService: start idle_loop on IDLE subscribe; stop on error/done. Wrap header batch fetches with fetch_headers_batch.
+  - BgFetchIos: start bg_fetch_ios_cycle on coalesced run; stop in finally.
+  - ConnectivityMonitor: start reconnect_window on regain; stop after refresh completes.
+- How to run:
+  flutter run -d <device> | \
+    dart run scripts/perf/sample_sync.dart | \
+    dart run scripts/perf/parse_frame_timings.dart
+- Budgets (observe only):
+  - idle_loop_dropped_pct_p50 <= 5%
+  - fetch_headers_batch_dropped_pct_p50 <= 5%
+  - bg_fetch_ios_cycle_dropped_pct_p50 <= 5%
+  - reconnect_window_dropped_pct_p50 <= 5%
+

--- a/lib/observability/perf/bg_perf_sampler.dart
+++ b/lib/observability/perf/bg_perf_sampler.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/widgets.dart';
+import 'package:wahda_bank/shared/logging/telemetry.dart';
+
+/// BgPerfSampler
+/// Generic sampler for background/sync windows. Captures frame timings if available
+/// and always measures wall-clock latency. Emits a single telemetry event on stop().
+/// Fields: op, latency_ms, jank_frames, total_frames, dropped_pct, request_id (optional)
+class BgPerfSampler {
+  final String opName; // e.g. "idle_loop", "fetch_headers_batch", "bg_fetch_ios_cycle", "reconnect_window"
+  final String? requestId;
+
+  static const double _frameBudgetMs = 16.67; // 60Hz
+
+  bool _active = false;
+  late final DateTime _startAt;
+  final List<FrameTiming> _frames = <FrameTiming>[];
+  final List<double> _syntheticFrameMs = <double>[]; // test-only fallback
+  TimingsCallback? _timingsCallback;
+
+  BgPerfSampler({required this.opName, this.requestId});
+
+  void start() {
+    if (_active) return;
+    _active = true;
+    _startAt = DateTime.now();
+    _timingsCallback = (List<FrameTiming> timings) {
+      if (!_active) return;
+      _frames.addAll(timings);
+    };
+    // Attach timings; if running in a headless context, callbacks may simply not fire.
+    SchedulerBinding.instance.addTimingsCallback(_timingsCallback!);
+  }
+
+  void stop() {
+    if (!_active) return;
+    _active = false;
+    if (_timingsCallback != null) {
+      SchedulerBinding.instance.removeTimingsCallback(_timingsCallback!);
+      _timingsCallback = null;
+    }
+    final summary = buildSummary();
+    Telemetry.event('operation', props: summary);
+  }
+
+  Map<String, Object?> buildSummary() {
+    final durMs = DateTime.now().difference(_startAt).inMilliseconds;
+    final totalFrames = _frames.isNotEmpty ? _frames.length : _syntheticFrameMs.length;
+    int jank = 0;
+    if (_frames.isNotEmpty) {
+      for (final f in _frames) {
+        final total = (f.totalSpan.inMicroseconds) / 1000.0; // ms
+        if (total > _frameBudgetMs) jank++;
+      }
+    } else {
+      for (final ms in _syntheticFrameMs) {
+        if (ms > _frameBudgetMs) jank++;
+      }
+    }
+    final droppedPct = totalFrames == 0 ? 0.0 : (jank / totalFrames) * 100.0;
+    return <String, Object?>{
+      'op': opName,
+      'latency_ms': durMs,
+      'jank_frames': jank,
+      'total_frames': totalFrames,
+      'dropped_pct': double.parse(droppedPct.toStringAsFixed(2)),
+      if (requestId != null) 'request_id': requestId,
+    };
+  }
+
+  @visibleForTesting
+  void ingestSyntheticFrameDurations(List<double> frameMs) {
+    _syntheticFrameMs.addAll(frameMs);
+  }
+}

--- a/scripts/perf/sample_sync.dart
+++ b/scripts/perf/sample_sync.dart
@@ -1,0 +1,21 @@
+// Filters background/sync perf telemetry lines from flutter run output.
+// Usage: flutter run -d <device> | dart run scripts/perf/sample_sync.dart
+import 'dart:convert';
+import 'dart:io';
+
+void main(List<String> args) async {
+  final ops = <String>{
+    'idle_loop',
+    'fetch_headers_batch',
+    'bg_fetch_ios_cycle',
+    'reconnect_window',
+    'bg_fetch',
+  };
+  final input = stdin.transform(utf8.decoder).transform(const LineSplitter());
+  await for (final line in input) {
+    final lower = line.toLowerCase();
+    if (lower.contains('[telemetry]') && ops.any((op) => lower.contains(op))) {
+      stdout.writeln(line);
+    }
+  }
+}

--- a/test/features/sync/bg_idle_sampler_smoke_test.dart
+++ b/test/features/sync/bg_idle_sampler_smoke_test.dart
@@ -1,0 +1,99 @@
+import 'dart:async';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wahda_bank/features/messaging/domain/entities/folder.dart';
+import 'package:wahda_bank/features/messaging/domain/entities/message.dart';
+import 'package:wahda_bank/features/messaging/domain/entities/attachment.dart';
+import 'package:wahda_bank/features/messaging/domain/entities/search_result.dart';
+import 'package:wahda_bank/features/messaging/domain/value_objects/search_query.dart';
+import 'package:wahda_bank/features/messaging/domain/repositories/message_repository.dart' as repo;
+import 'package:wahda_bank/features/messaging/infrastructure/gateways/imap_gateway.dart';
+import 'package:wahda_bank/features/sync/infrastructure/bg_fetch_ios.dart';
+import 'package:wahda_bank/features/sync/application/event_bus.dart';
+import 'package:wahda_bank/features/sync/infrastructure/circuit_breaker.dart';
+import 'package:wahda_bank/features/sync/infrastructure/connectivity_monitor.dart';
+import 'package:wahda_bank/features/sync/infrastructure/sync_service.dart';
+
+class _FakeGateway implements ImapGateway {
+  final StreamController<ImapEvent> ctrl = StreamController<ImapEvent>();
+  @override
+  Stream<ImapEvent> idleStream({required String accountId, required String folderId}) => ctrl.stream;
+  @override
+  Future<List<HeaderDTO>> fetchHeaders({required String accountId, required String folderId, int limit = 50, int offset = 0}) async => const [];
+  @override
+  Future<List<HeaderDTO>> searchHeaders({required String accountId, required String folderId, required SearchQuery q}) async => const [];
+  @override
+  Future<BodyDTO> fetchBody({required String accountId, required String folderId, required String messageUid}) async => const BodyDTO(messageUid: '', mimeType: 'text/plain');
+  @override
+  Future<List<AttachmentDTO>> listAttachments({required String accountId, required String folderId, required String messageUid}) async => const [];
+  @override
+  Future<List<int>> downloadAttachment({required String accountId, required String folderId, required String messageUid, required String partId}) async => const [];
+}
+
+class _FakeRepo implements repo.MessageRepository {
+  @override
+  Future<List<Message>> fetchInbox({required Folder folder, int limit = 50, int offset = 0}) async => <Message>[];
+  @override
+  Future<Message> fetchMessageBody({required Folder folder, required String messageId}) async => throw UnimplementedError();
+  @override
+  Future<List<Attachment>> listAttachments({required Folder folder, required String messageId}) async => <Attachment>[];
+  @override
+  Future<List<int>> downloadAttachment({required Folder folder, required String messageId, required String partId}) async => <int>[];
+  @override
+  Future<void> markRead({required Folder folder, required String messageId, required bool read}) async {}
+  @override
+  Future<List<SearchResult>> search({required String accountId, required SearchQuery q}) async => <SearchResult>[];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('idle_loop sampler starts/stops across IDLE window', () async {
+    final gw = _FakeGateway();
+    final repo = _FakeRepo();
+    final svc = SyncService(gateway: gw, messages: repo);
+    unawaited(svc.start(accountId: 'acc', folderId: 'INBOX'));
+    // Emit a couple of events then close
+    gw.ctrl.add(const ImapEvent(type: ImapEventType.exists, folderId: 'INBOX'));
+    gw.ctrl.add(const ImapEvent(type: ImapEventType.flagsChanged, folderId: 'INBOX'));
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    await gw.ctrl.close();
+    // Let onDone run
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    await svc.stop();
+  });
+
+  test('bg_fetch_ios_cycle sampler wraps coalesced run', () async {
+    final repo = _FakeRepo();
+    final cb = CircuitBreaker();
+    final bus = _NoopBus();
+    final bg = BgFetchIos(messages: repo, circuitBreaker: cb, bus: bus, registerFn: () async => true);
+    await bg.start();
+    bg.tick(folderId: 'INBOX');
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  });
+
+  test('reconnect_window sampler wraps connectivity regain refresh', () async {
+    final repo = _FakeRepo();
+    final cb = CircuitBreaker();
+    final streamCtrl = StreamController<List<ConnectivityResult>>();
+    final mon = ConnectivityMonitor(messages: repo, circuitBreaker: cb, stream: streamCtrl.stream);
+    unawaited(mon.start(folderId: 'INBOX'));
+    streamCtrl.add(<ConnectivityResult>[ConnectivityResult.wifi]);
+    await Future<void>.delayed(const Duration(milliseconds: 2500));
+    await mon.stop();
+    await streamCtrl.close();
+  });
+}
+
+class _NoopBus implements SyncEventBus {
+  @override
+  void publishBgFetchTick({required String folderId}) {}
+
+  @override
+  void publishNewMessageArrived({required String folderId}) {}
+
+  @override
+  void publishSyncFailed({required String folderId, required String errorClass}) {}
+}

--- a/test/features/sync/infrastructure/sync_service_idle_test.dart
+++ b/test/features/sync/infrastructure/sync_service_idle_test.dart
@@ -35,6 +35,7 @@ class _FakeGateway implements ImapGateway {
 }
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
   setUpAll(() {
     registerFallbackValue(const entities.Folder(id: 'INBOX', name: 'INBOX', isInbox: true));
   });

--- a/test/features/sync/p14_bg_fetch_coalescing_test.dart
+++ b/test/features/sync/p14_bg_fetch_coalescing_test.dart
@@ -61,6 +61,7 @@ class _NoopBus implements SyncEventBus {
 }
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
   test('BG fetch coalesces multiple ticks into a single repo call', () async {
     final repo = _FakeRepo();
     final cb = CircuitBreaker(failureThreshold: 2);

--- a/test/features/sync/p14_connectivity_monitor_test.dart
+++ b/test/features/sync/p14_connectivity_monitor_test.dart
@@ -38,6 +38,7 @@ class _FakeRepo implements dom.MessageRepository {
 }
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
   test('Connectivity regain triggers single refresh (debounced)', () async {
     final repo = _FakeRepo();
     final cb = CircuitBreaker();

--- a/test/observability/bg_perf_sampler_test.dart
+++ b/test/observability/bg_perf_sampler_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wahda_bank/observability/perf/bg_perf_sampler.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('BgPerfSampler aggregates dropped_pct correctly', () {
+    final sampler = BgPerfSampler(opName: 'idle_loop');
+    sampler.start();
+    // Two janky frames out of four => 50%
+    sampler.ingestSyntheticFrameDurations([10.0, 30.0, 12.0, 25.0]);
+    final summary = sampler.buildSummary();
+    expect(summary['op'], 'idle_loop');
+    expect(summary['total_frames'], 4);
+    expect(summary['jank_frames'], 2);
+    final dropped = summary['dropped_pct'] as double;
+    expect(dropped >= 49.9 && dropped <= 50.1, isTrue);
+    sampler.stop();
+  });
+}


### PR DESCRIPTION
{
  "phase": "P28",
  "title": "Background perf sampling — sync/idle & bg_fetch (no feature change)",
  "branch": "feat/ddd-p28-perf-sampling-sync-idle",
  "goal": "Instrument background IMAP IDLE, iOS BG fetch, and reconnect/coalescing windows with lightweight frame/latency telemetry; keep behavior/visuals 1:1.",
  "create_files": [
    "lib/observability/perf/bg_perf_sampler.dart",
    "scripts/perf/sample_sync.dart"
  ],
  "refactor_files": [
    "lib/features/sync/infrastructure/sync_service.dart",
    "lib/features/sync/infrastructure/bg_fetch_ios.dart",
    "lib/features/sync/infrastructure/connectivity_monitor.dart"
  ],
  "ops": [
    "idle_loop",
    "fetch_headers_batch",
    "bg_fetch_ios_cycle",
    "reconnect_window"
  ],
  "telemetry_fields": [
    "op", "latency_ms", "jank_frames", "total_frames", "dropped_pct", "request_id"
  ],
  "guardrails": [
    "No behavior/UI changes",
    "No new dependencies",
    "Import enforcer hard-fails new Colors.* in presentation/views (DS/theme excluded)",
    "Flags OFF; kill-switch > flags"
  ],
  "tests": [
    "unit: bg_perf_sampler aggregates dropped_pct correctly",
    "smoke: idle_loop/bg_fetch/reconnect samplers start and stop as expected with fakes"
  ],
  "acceptance": [
    "dart run tool/import_enforcer.dart passes",
    "dart analyze: 0 errors (warnings OK)",
    "flutter test --no-pub test: PASS",
    "Visuals unchanged; telemetry lines present for all ops"
  ]
}