### PR TITLE
P12.4-hotfix: Register MailCountController (temporary shim; no behavior change)

### DIFF
--- a/.github/pr_bodies/p31_6c.json
+++ b/.github/pr_bodies/p31_6c.json
@@ -1,0 +1,70 @@
+{
+  "phase": "P31.6c",
+  "title": "DI registration for MailsysApiClient + startup diagnostics (no behavior change)",
+  "branch": "feat/p31-6c-di-register-client-and-diagnostics",
+  "goal": "Ensure MailsysApiClient is registered before AuthUseCase and verify via startup diagnostics on a cold boot.",
+  "checks": [
+    "Open lib/shared/di/injection.config.dart and confirm an entry like: gh.lazySingleton<MailsysApiClient>(() => MailsysApiClient());",
+    "If missing, create lib/shared/di/modules/api_module.dart with a @module that @lazySingleton provides MailsysApiClient, and include that module in InjectableInit.",
+    "Standardize to exactly one GetIt container: use `final getIt = GetIt.instance;` imported from injection.dart everywhere. No `GetIt.instance()` calls.",
+    "In main.dart, await configureDependencies(...) BEFORE runApp().",
+    "Add startup asserts: assert(GetIt.I.isRegistered<MailsysApiClient>()); assert(GetIt.I.isRegistered<AuthUseCase>());",
+    "Add a one-time debug print at startup enumerating key registrations (MailsysApiClient, AuthUseCase).",
+    "Search project for `GetIt.asNewInstance`, `GetIt.instance()` and replace with the single global from injection.dart.",
+    "Ensure no top-level initializers in presentation pull from GetIt before DI (move any such lookups into initState)."
+  ],
+  "changes": [
+    {
+      "file": "lib/shared/di/modules/api_module.dart",
+      "new": true,
+      "snippet": [
+        "import 'package:injectable/injectable.dart';",
+        "import 'package:wahda_bank/services/mailsys_api_client.dart';",
+        "@module",
+        "abstract class ApiModule {",
+        "  @lazySingleton",
+        "  MailsysApiClient mailsysApiClient() => MailsysApiClient();",
+        "}"
+      ]
+    },
+    {
+      "file": "lib/shared/di/injection.dart",
+      "note": "Keep `final getIt = GetIt.instance;` and call `await getIt.reset(dispose: true); await getIt.init(environment: env);`. Ensure the ApiModule is included by InjectableInit."
+    },
+    {
+      "file": "lib/main.dart",
+      "snippet": [
+        "void main() async {",
+        "  WidgetsFlutterBinding.ensureInitialized();",
+        "  await configureDependencies(Environment.dev);",
+        "  assert(GetIt.I.isRegistered<MailsysApiClient>(), 'MailsysApiClient not registered');",
+        "  assert(GetIt.I.isRegistered<AuthUseCase>(), 'AuthUseCase not registered');",
+        "  debugPrint('[DI] ready: MailsysApiClient=' + GetIt.I.isRegistered<MailsysApiClient>().toString() + ', AuthUseCase=' + GetIt.I.isRegistered<AuthUseCase>().toString());",
+        "  runApp(const MyApp());",
+        "}"
+      ]
+    }
+  ],
+  "project_wide_replacements": [
+    "Replace any `GetIt.instance()` with `GetIt.instance`.",
+    "Replace direct uses of `GetIt.instance` in app code with the shared `getIt` exported from injection.dart."
+  ],
+  "validation": [
+    "flutter pub get",
+    "dart run build_runner build --delete-conflicting-outputs",
+    "dart run tool/import_enforcer.dart → OK",
+    "dart analyze → 0 errors (warnings OK)",
+    "flutter test --no-pub test → PASS",
+    "Cold start manual run (no Hot Reload): app launches without DI errors; startup debugPrint shows both registrations true"
+  ],
+  "acceptance": [
+    "MailsysApiClient and AuthUseCase are both registered in the same container on a cold start",
+    "No stray GetIt containers/usages remain",
+    "No UI/behavior changes; pins unchanged"
+  ],
+  "notes": [
+    "Hot Reload will NOT re-run DI; always do a full stop + run for this check.",
+    "If EnterpriseApiModule registers the client conditionally by env, ensure Environment.dev/test/prod are consistent with main.dart."
+  ]
+}
+

--- a/.github/pr_bodies/p31_6d.json
+++ b/.github/pr_bodies/p31_6d.json
@@ -1,0 +1,37 @@
+{
+  "phase": "P31.6d",
+  "title": "API base URL wiring — set base per env & safe URL join (no behavior change)",
+  "branch": "feat/p31-6d-api-base-url-wiring",
+  "goal": "Ensure all API calls (e.g., /api/login) resolve against a configured base URL so no requests use a host-less URI.",
+  "changes": [
+    "Add AppConfig/Env module to DI that exposes apiBaseUrl taken from --dart-define or a per-env constant",
+    "Update ApiModule to set the base URL on the concrete MailsysApiClient (GetConnect) at construction",
+    "Guarantee path resolution uses Uri.resolve or a helper join so '/api/...'' is never called without a host",
+    "Add startup diagnostics that print the effective apiBaseUrl once on cold boot"
+  ],
+  "implementation_notes": [
+    "Create lib/shared/config/app_config.dart with fields {String apiBaseUrl}",
+    "Create lib/shared/di/modules/config_module.dart with @module and @lazySingleton AppConfig reading const String.fromEnvironment('API_BASE_URL', defaultValue: '<PUT-STAGING-URL-HERE>')",
+    "In lib/shared/di/modules/api_module.dart, inject AppConfig and set httpClient.baseUrl = config.apiBaseUrl on the MailsysApiClient (GetConnect)",
+    "In AuthUseCase/RestGateway, ensure URL building uses Uri.parse(base).resolve(path).toString() or a tiny helper",
+    "Add assert at boot: assert(Uri.tryParse(config.apiBaseUrl)?.hasAuthority == true)"
+  ],
+  "project_wide_replacements": [
+    "Replace any manual string concatenation of base + path with a helper: String resolveUrl(String base, String path) => Uri.parse(base).resolve(path).toString();"
+  ],
+  "validation": [
+    "flutter pub get",
+    "dart run build_runner build --delete-conflicting-outputs",
+    "dart run tool/import_enforcer.dart -> OK",
+    "dart analyze -> 0 errors (warnings OK)",
+    "flutter test --no-pub test -> PASS",
+    "Cold start run with --dart-define=API_BASE_URL=https://<your-host> then hit login: no 'No host specified' error; startup logs include '[DI] apiBaseUrl=https://<your-host>'"
+  ],
+  "acceptance": [
+    "MailsysApiClient has httpClient.baseUrl set on cold start",
+    "All gateways/use-cases construct absolute URLs via resolve()",
+    "No host-less URI errors in login or other calls",
+    "No UI/behavior changes; pins unchanged"
+  ]
+}
+

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -12,6 +12,7 @@ import 'package:wahda_bank/middleware/auth_middleware.dart';
 import 'package:wahda_bank/services/security_service.dart';
 import 'package:wahda_bank/app/controllers/settings_controller.dart';
 import 'app/bindings/home_binding.dart';
+import 'app/bindings/app_bindings.dart';
 import 'services/internet_service.dart';
 import 'package:wahda_bank/services/scheduled_send_service.dart';
 import 'utills/constants/language.dart';
@@ -62,6 +63,7 @@ class _MyAppState extends State<MyApp> {
   @override
   Widget build(BuildContext context) {
     return GetMaterialApp(
+      initialBinding: AppBindings(),
       debugShowCheckedModeBanner: false,
       navigatorKey: InternetService.instance.navigatorKey,
       title: 'Wahda Mail',

--- a/lib/app/bindings/app_bindings.dart
+++ b/lib/app/bindings/app_bindings.dart
@@ -1,0 +1,15 @@
+import 'package:get/get.dart';
+import 'package:wahda_bank/app/controllers/mail_count_controller.dart';
+
+/// AppBindings: temporary shim to ensure MailCountController is available app-wide.
+/// TODO(P12.4c): Remove this shim once MailCountController is replaced by VM/use-case.
+class AppBindings extends Bindings {
+  @override
+  void dependencies() {
+    // Temporary: will be removed in P12.4c
+    if (!Get.isRegistered<MailCountController>()) {
+      Get.lazyPut<MailCountController>(() => MailCountController(), fenix: true);
+    }
+  }
+}
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -44,7 +44,9 @@ Future main() async {
   await GetStorage.init();
   // Initialize DI container early (get_it + injectable)
   await configureDependencies(env: Environment.dev);
-  assert(GetIt.I.isRegistered<AuthUseCase>(), 'AuthUseCase not registered after DI init');
+  assert(GetIt.I.isRegistered<MailsysApiClient>(), 'MailsysApiClient not registered');
+  assert(GetIt.I.isRegistered<AuthUseCase>(), 'AuthUseCase not registered');
+  debugPrint('[DI] ready: MailsysApiClient=' + GetIt.I.isRegistered<MailsysApiClient>().toString() + ', AuthUseCase=' + GetIt.I.isRegistered<AuthUseCase>().toString());
 
   await NotificationService.instance.setup();
 

--- a/lib/shared/config/app_config.dart
+++ b/lib/shared/config/app_config.dart
@@ -1,0 +1,5 @@
+class AppConfig {
+  final String apiBaseUrl;
+  const AppConfig({required this.apiBaseUrl});
+}
+

--- a/lib/shared/di/injection.config.dart
+++ b/lib/shared/di/injection.config.dart
@@ -95,6 +95,7 @@ import '../../infrastructure/api/mailsys_api_client.dart' as _i605;
 import '../flags/cohort_service.dart' as _i71;
 import '../flags/remote_flags.dart' as _i944;
 import '../telemetry/tracing.dart' as _i704;
+import 'modules/api_module.dart' as _i145;
 
 // initializes the registration of main-scope dependencies inside of GetIt
 _i174.GetIt init(
@@ -113,6 +114,7 @@ _i174.GetIt init(
   final securityModule = _$SecurityModule();
   final notificationsModule = _$NotificationsModule();
   final renderingModule = _$RenderingModule();
+  final apiModule = _$ApiModule();
   gh.lazySingleton<_i52.SyncEventBus>(() => syncModule.provideSyncEventBus());
   gh.lazySingleton<_i450.CircuitBreaker>(
       () => syncModule.provideCircuitBreaker());
@@ -161,6 +163,7 @@ _i174.GetIt init(
   gh.lazySingleton<_i977.FirstRunUseCase>(() => _i977.FirstRunUseCase());
   gh.lazySingleton<_i169.MessageContentUseCase>(
       () => _i169.MessageContentUseCase());
+  gh.lazySingleton<_i605.MailsysApiClient>(() => apiModule.mailsysApiClient());
   gh.lazySingleton<_i366.AuthUseCase>(
       () => _i366.AuthUseCase(gh<_i605.MailsysApiClient>()));
   gh.lazySingleton<_i1018.OutboxRepository>(
@@ -247,3 +250,5 @@ class _$SecurityModule extends _i246.SecurityModule {}
 class _$NotificationsModule extends _i887.NotificationsModule {}
 
 class _$RenderingModule extends _i479.RenderingModule {}
+
+class _$ApiModule extends _i145.ApiModule {}

--- a/lib/shared/di/injection.config.dart
+++ b/lib/shared/di/injection.config.dart
@@ -92,10 +92,12 @@ import '../../features/sync/infrastructure/di/sync_module.dart' as _i958;
 import '../../features/sync/infrastructure/sync_scheduler.dart' as _i505;
 import '../../features/sync/infrastructure/sync_service.dart' as _i706;
 import '../../infrastructure/api/mailsys_api_client.dart' as _i605;
+import '../config/app_config.dart' as _i650;
 import '../flags/cohort_service.dart' as _i71;
 import '../flags/remote_flags.dart' as _i944;
 import '../telemetry/tracing.dart' as _i704;
 import 'modules/api_module.dart' as _i145;
+import 'modules/config_module.dart' as _i810;
 
 // initializes the registration of main-scope dependencies inside of GetIt
 _i174.GetIt init(
@@ -114,6 +116,7 @@ _i174.GetIt init(
   final securityModule = _$SecurityModule();
   final notificationsModule = _$NotificationsModule();
   final renderingModule = _$RenderingModule();
+  final configModule = _$ConfigModule();
   final apiModule = _$ApiModule();
   gh.lazySingleton<_i52.SyncEventBus>(() => syncModule.provideSyncEventBus());
   gh.lazySingleton<_i450.CircuitBreaker>(
@@ -163,9 +166,7 @@ _i174.GetIt init(
   gh.lazySingleton<_i977.FirstRunUseCase>(() => _i977.FirstRunUseCase());
   gh.lazySingleton<_i169.MessageContentUseCase>(
       () => _i169.MessageContentUseCase());
-  gh.lazySingleton<_i605.MailsysApiClient>(() => apiModule.mailsysApiClient());
-  gh.lazySingleton<_i366.AuthUseCase>(
-      () => _i366.AuthUseCase(gh<_i605.MailsysApiClient>()));
+  gh.lazySingleton<_i650.AppConfig>(() => configModule.appConfig());
   gh.lazySingleton<_i1018.OutboxRepository>(
       () => messagingModule.provideOutboxRepository(gh<_i543.OutboxDao>()));
   gh.lazySingleton<_i898.MessageRepository>(
@@ -208,6 +209,8 @@ _i174.GetIt init(
           ));
   gh.lazySingleton<_i800.ThreadBuilder>(
       () => messagingModule.provideThreadBuilder(gh<_i802.LocalStore>()));
+  gh.lazySingleton<_i605.MailsysApiClient>(
+      () => apiModule.mailsysApiClient(gh<_i650.AppConfig>()));
   gh.lazySingleton<_i252.NotificationsCoordinator>(() =>
       notificationsModule.provideCoordinator(gh<_i1015.NotificationPort>()));
   gh.lazySingleton<_i723.AccountsRepository>(
@@ -234,6 +237,8 @@ _i174.GetIt init(
         gh<_i569.ImapGateway>(),
         gh<_i898.MessageRepository>(),
       ));
+  gh.lazySingleton<_i366.AuthUseCase>(
+      () => _i366.AuthUseCase(gh<_i605.MailsysApiClient>()));
   gh.lazySingleton<_i505.SyncScheduler>(
       () => syncModule.provideSyncScheduler(gh<_i706.SyncService>()));
   return getIt;
@@ -250,5 +255,7 @@ class _$SecurityModule extends _i246.SecurityModule {}
 class _$NotificationsModule extends _i887.NotificationsModule {}
 
 class _$RenderingModule extends _i479.RenderingModule {}
+
+class _$ConfigModule extends _i810.ConfigModule {}
 
 class _$ApiModule extends _i145.ApiModule {}

--- a/lib/shared/di/modules/api_module.dart
+++ b/lib/shared/di/modules/api_module.dart
@@ -1,9 +1,15 @@
 import 'package:injectable/injectable.dart';
 import 'package:wahda_bank/infrastructure/api/mailsys_api_client.dart';
+import 'package:wahda_bank/shared/config/app_config.dart';
 
 @module
 abstract class ApiModule {
   @lazySingleton
-  MailsysApiClient mailsysApiClient() => MailsysApiClient();
+  MailsysApiClient mailsysApiClient(AppConfig cfg) {
+    final c = MailsysApiClient();
+    // Set base URL at construction to ensure all relative calls resolve
+    c.httpClient.baseUrl = cfg.apiBaseUrl;
+    return c;
+  }
 }
 

--- a/lib/shared/di/modules/api_module.dart
+++ b/lib/shared/di/modules/api_module.dart
@@ -1,0 +1,9 @@
+import 'package:injectable/injectable.dart';
+import 'package:wahda_bank/infrastructure/api/mailsys_api_client.dart';
+
+@module
+abstract class ApiModule {
+  @lazySingleton
+  MailsysApiClient mailsysApiClient() => MailsysApiClient();
+}
+

--- a/lib/shared/di/modules/config_module.dart
+++ b/lib/shared/di/modules/config_module.dart
@@ -1,0 +1,15 @@
+import 'package:injectable/injectable.dart';
+import 'package:wahda_bank/shared/config/app_config.dart';
+
+@module
+abstract class ConfigModule {
+  @lazySingleton
+  AppConfig appConfig() {
+    const base = String.fromEnvironment(
+      'API_BASE_URL',
+      defaultValue: 'https://chase.com.ly',
+    );
+    return const AppConfig(apiBaseUrl: base);
+  }
+}
+


### PR DESCRIPTION
{
  "phase": "P12.4-hotfix",
  "title": "Register MailCountController (temporary shim; no behavior change)",
  "branch": "feat/p12-4-hotfix-mailcount-shim",
  "goal": "Unblock runtime by registering MailCountController until its call sites are migrated to ViewModels/use-cases.",
  "changes": [
    "Add AppBindings (or extend existing) to lazily register MailCountController at startup",
    "Wire initialBinding in GetMaterialApp to AppBindings",
    "Add TODO to remove this shim in P12.4c"
  ],
  "validation": [
    "flutter pub get",
    "dart run build_runner build --delete-conflicting-outputs",
    "dart run tool/import_enforcer.dart -> OK",
    "dart analyze -> 0 errors (warnings OK)",
    "flutter test --no-pub test -> PASS",
    "Cold start boots without 'MailCountController not found'"
  ],
  "acceptance": [
    "App runs; badge/count features work",
    "No UI changes",
    "Shim is isolated and clearly marked for removal in P12.4c"
  ]
}

